### PR TITLE
Fixes for non-blocking handler signatures.

### DIFF
--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
@@ -32,7 +32,7 @@ public extension OperationHandler {
           handling the operation
      */
     public init<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
-            operation: @escaping ((InputType, ContextType, (Swift.Error?) -> ()) throws -> ()),
+            operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType? = nil) {
         
@@ -110,7 +110,7 @@ public extension SmokeHTTP1HandlerSelector {
     public mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, (Swift.Error?) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType? = nil) {
             let handler = OperationHandler(operation: operation,

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
@@ -33,7 +33,7 @@ public extension OperationHandler {
      */
     public init<InputType: ValidatableCodable, OutputType: ValidatableCodable,
             ErrorType: ErrorIdentifiableByDescription>(
-            operation: @escaping ((InputType, ContextType, (SmokeResult<OutputType>) -> ()) throws -> ()),
+            operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType? = nil) {
         
@@ -113,7 +113,7 @@ public extension SmokeHTTP1HandlerSelector {
             ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, (SmokeResult<OutputType>) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType? = nil) {
             let handler = OperationHandler(operation: operation,


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Async handler signatures will most likely require escaping completion handlers if they are passed outside of the lifetime of the handler. Ensure the async completion is handled on a thread in the SwiftNIO event loop.


*Testing:* Tested both sync and async handler signatures with this change. They completed as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
