### PR TITLE
Add an invocation strategy protocol to specify how to invoke the HTTP1RequestHandler

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "5d8148c8b45dfb449276557f22120694567dd1d2",
-          "version": "1.9.5"
+          "revision": "176dd6e8564d60e936b76f3a896d667ae3acba31",
+          "version": "1.10.0"
         }
       },
       {

--- a/Sources/SmokeHTTP1/GlobalDispatchQueueInvocationStrategy.swift
+++ b/Sources/SmokeHTTP1/GlobalDispatchQueueInvocationStrategy.swift
@@ -1,0 +1,36 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  GlobalDispatchQueueAsyncInvocationStrategy.swift
+//  SmokeHTTP1
+//
+
+import Foundation
+
+/**
+ An AsyncInvocationStrategy that will invocate the handler on
+ DispatchQueue.global().
+ */
+public struct GlobalDispatchQueueInvocationStrategy: InvocationStrategy {
+    let queue = DispatchQueue.global()
+    
+    public init() {
+        
+    }
+    
+    public func invoke(handler: @escaping () -> ()) {
+        queue.async {
+            handler()
+        }
+    }
+}

--- a/Sources/SmokeHTTP1/InvocationStrategy.swift
+++ b/Sources/SmokeHTTP1/InvocationStrategy.swift
@@ -1,0 +1,32 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AsyncInvocationStrategy.swift
+//  SmokeHTTP1
+//
+
+import Foundation
+
+/**
+ A strategy protocol that manages how to invocate a handler.
+ */
+public protocol InvocationStrategy {
+    
+    /**
+     Function to handle the invocation of the handler.
+ 
+     - Parameters:
+        - handler: The handler to invocate.
+     */
+    func invoke(handler: @escaping () -> ())
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -34,7 +34,8 @@ public extension SmokeHTTP1Server {
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
         defaultOperationDelegate: OperationDelegateType,
-        andPort port: Int = ServerDefaults.defaultPort) throws
+        andPort port: Int = ServerDefaults.defaultPort,
+        invocationStrategy: InvocationStrategy = GlobalDispatchQueueInvocationStrategy()) throws
         where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
         SelectorType.OperationDelegateType == OperationDelegateType, OperationDelegateType.RequestType == SmokeHTTP1Request,
         OperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler {
@@ -42,7 +43,8 @@ public extension SmokeHTTP1Server {
                                                              context: context,
                                                              defaultOperationDelegate: defaultOperationDelegate)
             let server = SmokeHTTP1Server(handler: handler,
-                                          port: port)
+                                          port: port,
+                                          invocationStrategy: invocationStrategy)
             
             Log.info("Server starting on port \(port)...")
         


### PR DESCRIPTION
Add an invocation strategy protocol to specify how to invoke the HTTP1RequestHandler in the HTTP1ChannelInboundHandler.

*Description of changes:*

By default, we will hand off invocation to DispatchQueue.global() to avoid handling operations on the thread directly
from SwiftNIO.

We already do this for our clients but assumed server threading would be fine. Adding a separate InvocationStrategy
here until we unify client and server code.

Related SwiftNIO issues-
 * https://github.com/apple/swift-nio/pull/553
 * https://github.com/apple/swift-nio/pull/578

Similar issues for other frameworks-
 * vapor - https://github.com/vapor/vapor/issues/1788
 * Kitura-NIO - https://github.com/IBM-Swift/Kitura-NIO/issues/66

*Testing:*

Verified by running a request against a service that then called a SwiftNIO client. Returned output as expected without error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
