### PR TITLE
Fix tests compile error on Linux.

### DIFF
--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
@@ -121,7 +121,7 @@ private func verifyErrorResponse(uri: String) {
     XCTAssertEqual("Is bad!", output.reason)
 }
 
-class SmokeOperationsAsyncTests: XCTestCase {
+class SmokeOperationsHTTP1AsyncTests: XCTestCase {
     
     func testExampleHandler() {
         let response = verifyPathOutput(uri: "exampleOperation",

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
@@ -92,7 +92,7 @@ private func verifyErrorResponse(uri: String) {
     XCTAssertEqual("TheError", output.type)
 }
 
-class SmokeOperationsSyncTests: XCTestCase {
+class SmokeOperationsHTTP1SyncTests: XCTestCase {
     
     func testExampleHandler() {
         let response = verifyPathOutput(uri: "exampleOperation",


### PR DESCRIPTION
*Issue #, if available:* #12 

*Description of changes:* Missed renaming test classes as part of commit https://github.com/amzn/smoke-framework/commit/c84ecb5712f303a30129bdb150e86d6139196562. This caused tests to fail on Linux. Renamed these classes to match LinuxMain.

*Description of testing performed:* As test automation is not yet set up, manually verify tests now pass in the official Swift 4.2 Docker container.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
