### PR TITLE
Introduce a HTTP1ServerResponseComponents type to specify additional …

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
         "state": {
           "branch": null,
-          "revision": "5041f2673aa75d6e973d9b6bd3956bc5068387c8",
-          "version": "1.7.3"
+          "revision": "d0ccb4158b83f8692531892a9c894bb757593c6f",
+          "version": "1.8.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "176dd6e8564d60e936b76f3a896d667ae3acba31",
-          "version": "1.10.0"
+          "revision": "03c541a24dd0558c942b15d8464eb75d70a921c4",
+          "version": "1.12.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/SmokeHTTP1/HTTP1ResponseHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1ResponseHandler.swift
@@ -18,6 +18,7 @@
 import Foundation
 import NIO
 import NIOHTTP1
+import SmokeOperations
 
 /**
  A protocol that specifies a handler for a HTTP response.
@@ -29,9 +30,9 @@ public protocol HTTP1ResponseHandler {
  
      - Parameters:
         - status: the status to provide in the response.
-        - body: the content type and data to use for the response.
+        - responseComponents: the components to send in the response.
      */
-    func complete(status: HTTPResponseStatus, body: (contentType: String, data: Data)?)
+    func complete(status: HTTPResponseStatus, responseComponents: HTTP1ServerResponseComponents)
     
     /**
      Function used to provide a response to a HTTP request. The response will not be
@@ -42,12 +43,12 @@ public protocol HTTP1ResponseHandler {
         - body: the content type and data to use for the response.
      */
     func completeSilently(status: HTTPResponseStatus,
-                          body: (contentType: String, data: Data)?)
+                          responseComponents: HTTP1ServerResponseComponents)
 }
 
 public extension HTTP1ResponseHandler {
     func completeSilently(status: HTTPResponseStatus,
-                          body: (contentType: String, data: Data)?) {
-        complete(status: status, body: body)
+                          responseComponents: HTTP1ServerResponseComponents) {
+        complete(status: status, responseComponents: responseComponents)
     }
 }

--- a/Sources/SmokeHTTP1/HTTP1ServerResponseComponents.swift
+++ b/Sources/SmokeHTTP1/HTTP1ServerResponseComponents.swift
@@ -1,0 +1,32 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTP1ServerResponseComponents.swift
+//  SmokeHTTP1
+//
+
+import Foundation
+
+/// The parsed components that specify a request.
+public struct HTTP1ServerResponseComponents {
+    /// any additional response headers.
+    public let additionalHeaders: [(String, String)]
+    /// The body data of the response.
+    public let body: (contentType: String, data: Data)?
+
+    public init(additionalHeaders: [(String, String)],
+                body: (contentType: String, data: Data)?) {
+        self.additionalHeaders = additionalHeaders
+        self.body = body
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/JSONPayloadHTTP1OperationDelegate.swift
+++ b/Sources/SmokeOperationsHTTP1/JSONPayloadHTTP1OperationDelegate.swift
@@ -68,12 +68,17 @@ public struct JSONPayloadHTTP1OperationDelegate: OperationDelegate {
         
         let body = (contentType: MimeTypes.json, data: encodedOutput)
         
-        responseHandler.complete(status: .ok, body: body)
+        let responseComponents = HTTP1ServerResponseComponents(
+            additionalHeaders: [],
+            body: body)
+        
+        responseHandler.complete(status: .ok, responseComponents: responseComponents)
     }
     
     public func handleResponseForOperationWithNoOutput(request: SmokeHTTP1Request,
                                                        responseHandler: HTTP1ResponseHandler) {
-        responseHandler.complete(status: .ok, body: nil)
+        let responseComponents = HTTP1ServerResponseComponents(additionalHeaders: [], body: nil)
+        responseHandler.complete(status: .ok, responseComponents: responseComponents)
     }
     
     public func handleResponseForOperationFailure(request: SmokeHTTP1Request,
@@ -91,9 +96,10 @@ public struct JSONPayloadHTTP1OperationDelegate: OperationDelegate {
         }
         
         let body = (contentType: MimeTypes.json, data: encodedOutput)
+        let responseComponents = HTTP1ServerResponseComponents(additionalHeaders: [], body: body)
 
         responseHandler.complete(status: .custom(code: UInt(operationFailure.code), reasonPhrase: operationFailure.error.description),
-                                         body: body)
+                                         responseComponents: responseComponents)
     }
     
     public func handleResponseForInternalServerError(request: SmokeHTTP1Request,
@@ -125,8 +131,9 @@ public struct JSONPayloadHTTP1OperationDelegate: OperationDelegate {
                                                      reason: reason)
         
         let body = (contentType: MimeTypes.json, data: encodedError)
+        let responseComponents = HTTP1ServerResponseComponents(additionalHeaders: [], body: body)
 
         responseHandler.complete(status: .custom(code: UInt(code), reasonPhrase: reason),
-                                         body: body)
+                                         responseComponents: responseComponents)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
@@ -42,7 +42,8 @@ struct OperationServerHTTP1RequestHandler<ContextType, SelectorType, OperationDe
         // this is the ping url
         if requestHead.uri == PingParameters.uri {
             let body = (contentType: "text/plain", data: PingParameters.payload)
-            responseHandler.completeSilently(status: .ok, body: body)
+            let responseComponents = HTTP1ServerResponseComponents(additionalHeaders: [], body: body)
+            responseHandler.completeSilently(status: .ok, responseComponents: responseComponents)
             
             return
         }

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
@@ -114,8 +114,9 @@ private func verifyErrorResponse(uri: String) {
 
 
     XCTAssertEqual(response.status.code, 400)
+    let body = response.responseComponents.body!
     let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                          from: response.body!.data)
+                                                          from: body.data)
 
     XCTAssertEqual("TheError", output.type)
     XCTAssertEqual("Is bad!", output.reason)
@@ -129,8 +130,9 @@ class SmokeOperationsHTTP1AsyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 200)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(OutputAttributes.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         let expectedOutput = OutputAttributes(bodyColor: .blue, isGreat: true)
         XCTAssertEqual(expectedOutput, output)
     }
@@ -141,7 +143,8 @@ class SmokeOperationsHTTP1AsyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 200)
-        XCTAssertNil(response.body)
+        let body = response.responseComponents.body
+        XCTAssertNil(body)
     }
   
     func testInputValidationError() {
@@ -150,8 +153,9 @@ class SmokeOperationsHTTP1AsyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 400)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         
         XCTAssertEqual("ValidationError", output.type)
     }
@@ -162,8 +166,9 @@ class SmokeOperationsHTTP1AsyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 500)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         
         XCTAssertEqual("InternalError", output.type)
     }
@@ -181,8 +186,9 @@ class SmokeOperationsHTTP1AsyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 400)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         
         XCTAssertEqual("InvalidOperation", output.type)
     }
@@ -193,8 +199,9 @@ class SmokeOperationsHTTP1AsyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 400)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         
         XCTAssertEqual("InvalidOperation", output.type)
     }

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
@@ -86,8 +86,9 @@ private func verifyErrorResponse(uri: String) {
 
 
     XCTAssertEqual(response.status.code, 400)
+    let body = response.responseComponents.body!
     let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                          from: response.body!.data)
+                                                          from: body.data)
 
     XCTAssertEqual("TheError", output.type)
 }
@@ -100,8 +101,9 @@ class SmokeOperationsHTTP1SyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 200)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(OutputAttributes.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         let expectedOutput = OutputAttributes(bodyColor: .blue, isGreat: true)
         XCTAssertEqual(expectedOutput, output)
     }
@@ -112,7 +114,8 @@ class SmokeOperationsHTTP1SyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 200)
-        XCTAssertNil(response.body)
+        let body = response.responseComponents.body
+        XCTAssertNil(body)
     }
   
     func testInputValidationError() {
@@ -121,8 +124,9 @@ class SmokeOperationsHTTP1SyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 400)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         
         XCTAssertEqual("ValidationError", output.type)
     }
@@ -133,8 +137,9 @@ class SmokeOperationsHTTP1SyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 500)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         
         XCTAssertEqual("InternalError", output.type)
     }
@@ -150,8 +155,9 @@ class SmokeOperationsHTTP1SyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 400)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         
         XCTAssertEqual("InvalidOperation", output.type)
     }
@@ -162,8 +168,9 @@ class SmokeOperationsHTTP1SyncTests: XCTestCase {
 
         
         XCTAssertEqual(response.status.code, 400)
+        let body = response.responseComponents.body!
         let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                              from: response.body!.data)
+                                                              from: body.data)
         
         XCTAssertEqual("InvalidOperation", output.type)
     }

--- a/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
@@ -43,16 +43,16 @@ let serializedInvalidInput = """
 
 struct OperationResponse {
     let status: HTTPResponseStatus
-    let body: (contentType: String, data: Data)?
+    let responseComponents: HTTP1ServerResponseComponents
 }
 
 class TestHttpResponseHandler: HTTP1ResponseHandler {
     var response: OperationResponse?
     
     func complete(status: HTTPResponseStatus,
-                  body: (contentType: String, data: Data)?) {
+                  responseComponents: HTTP1ServerResponseComponents) {
         response = OperationResponse(status: status,
-                                    body: body)
+                                    responseComponents: responseComponents)
     }
 }
 


### PR DESCRIPTION
Introduce a HTTP1ServerResponseComponents type to specify additional headers and optionally a body for the response.

*Issue #, if available:* #5 

*Description of changes:* The first part of changes required to add support beyond body-only request and responses. Splitting up the changes to make them more manageable.

This change introduces a HTTP1ServerResponseComponents type to allow the completion call to the HTTP1ResponseHandler to specify any additional headers along with the optional response body.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
