### PR TITLE
Operation delegate type fix. Remove core Codable constraint.

### DIFF
--- a/Sources/SmokeOperations/OperationDelegate.swift
+++ b/Sources/SmokeOperations/OperationDelegate.swift
@@ -28,25 +28,6 @@ public protocol OperationDelegate {
     associatedtype ResponseHandlerType
     
     /**
-     Function to retrieve an instance of the InputType from the request. Will throw an error
-     if an instance of InputType cannot be constructed from the request.
-     */
-    func getInputForOperation<InputType: Decodable>(request: RequestType) throws -> InputType
-    
-    /**
-     Function to handle a successful response from an operation.
- 
-     - Parameters:
-        - request: The original request corresponding to the operation. Can be used to determine how to
-          handle the response (such as requested response type).
-        - output: The instance of the OutputType to send as a response.
-        - responseHander: typically a response handler specific to the transport protocol being used.
-     */
-    func handleResponseForOperation<OutputType: Encodable>(request: RequestType,
-                                                           output: OutputType,
-                                                           responseHandler: ResponseHandlerType)
-    
-    /**
      Function to handle a successful operation with no response.
  
      - Parameters:

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
@@ -30,24 +30,24 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation
      */
-    public init<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
-            operation: @escaping ((InputType, ContextType) throws -> ()),
+    public init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            inputProvider: @escaping (OperationDelegateType.RequestType) throws -> InputType,
+            outputProvider: @escaping ((InputType, ContextType) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
-            operationDelegate: OperationDelegateType? = nil) {
+            operationDelegate: OperationDelegateType)
+    where RequestType == OperationDelegateType.RequestType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
          * The wrapped input handler takes the provided operation handler and wraps it so that if it
          * returns, the responseHandler is called to indicate success. If the provided operation
          * throws an error, the responseHandler is called with that error.
          */
-        let wrappedInputHandler = { (input: InputType, request: OperationDelegateType.RequestType, context: ContextType,
-                                     defaultOperationDelegate: OperationDelegateType,
-                                     responseHandler: OperationDelegateType.ResponseHandlerType) in
-            let operationDelegateToUse = operationDelegate ?? defaultOperationDelegate
-
+        let wrappedInputHandler = { (input: InputType, request: RequestType, context: ContextType,
+                                     responseHandler: ResponseHandlerType) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>
             do {
-                try operation(input, context)
+                try outputProvider(input, context)
                 
                 handlerResult = .success
             } catch let smokeReturnableError as SmokeReturnableError {
@@ -60,11 +60,13 @@ public extension OperationHandler {
             
             OperationHandler.handleNoOutputOperationHandlerResult(
                 handlerResult: handlerResult,
-                operationDelegate: operationDelegateToUse,
+                operationDelegate: operationDelegate,
                 request: request,
                 responseHandler: responseHandler)
         }
         
-        self.init(wrappedInputHandler)
+        self.init(inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
     }
 }

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
@@ -24,15 +24,16 @@ public extension OperationHandler {
        a result with an empty body.
      
      - Parameters:
+        - inputProvider: function that obtains the input from the request.
         - operation: the handler method for the operation.
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
         - operationDelegate: optionally an operation-specific delegate to use when
-          handling the operation
+          handling the operation.
      */
     public init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             inputProvider: @escaping (OperationDelegateType.RequestType) throws -> InputType,
-            outputProvider: @escaping ((InputType, ContextType) throws -> ()),
+            operation: @escaping ((InputType, ContextType) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestType == OperationDelegateType.RequestType,
@@ -47,7 +48,7 @@ public extension OperationHandler {
                                      responseHandler: ResponseHandlerType) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>
             do {
-                try outputProvider(input, context)
+                try operation(input, context)
                 
                 handlerResult = .success
             } catch let smokeReturnableError as SmokeReturnableError {

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
@@ -24,16 +24,18 @@ public extension OperationHandler {
       a result body.
      
      - Parameters:
+        - inputProvider: function that obtains the input from the request.
         - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
         - operationDelegate: optionally an operation-specific delegate to use when
-          handling the operation
+          handling the operation.
      */
     public init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: OperationDelegate>(
             inputProvider: @escaping (RequestType) throws -> InputType,
-            outputProvider: @escaping (InputType, ContextType) throws -> OutputType,
+            operation: @escaping (InputType, ContextType) throws -> OutputType,
             outputHandler: @escaping ((RequestType, OutputType, ResponseHandlerType) -> Void),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
@@ -49,7 +51,7 @@ public extension OperationHandler {
                                      responseHandler: OperationDelegateType.ResponseHandlerType) in
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
             do {
-                let output = try outputProvider(input, context)
+                let output = try operation(input, context)
                 
                 handlerResult = .success(output)
             } catch let smokeReturnableError as SmokeReturnableError {

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
@@ -30,25 +30,26 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation
      */
-    public init<InputType: ValidatableCodable, OutputType: ValidatableCodable,
-            ErrorType: ErrorIdentifiableByDescription>(
-            operation: @escaping ((InputType, ContextType) throws -> OutputType),
+    public init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: OperationDelegate>(
+            inputProvider: @escaping (RequestType) throws -> InputType,
+            outputProvider: @escaping (InputType, ContextType) throws -> OutputType,
+            outputHandler: @escaping ((RequestType, OutputType, ResponseHandlerType) -> Void),
             allowedErrors: [(ErrorType, Int)],
-            operationDelegate: OperationDelegateType? = nil) {
+            operationDelegate: OperationDelegateType)
+    where RequestType == OperationDelegateType.RequestType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
          * The wrapped input handler takes the provided operation handler and wraps it so that if it
          * returns, the responseHandler is called with the result. If the provided operation
          * throws an error, the responseHandler is called with that error.
          */
-        let wrappedInputHandler = { (input: InputType, request: OperationDelegateType.RequestType, context: ContextType,
-                                     defaultOperationDelegate: OperationDelegateType,
+        let wrappedInputHandler = { (input: InputType, request: RequestType, context: ContextType,
                                      responseHandler: OperationDelegateType.ResponseHandlerType) in
-            let operationDelegateToUse = operationDelegate ?? defaultOperationDelegate
-            
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
             do {
-                let output = try operation(input, context)
+                let output = try outputProvider(input, context)
                 
                 handlerResult = .success(output)
             } catch let smokeReturnableError as SmokeReturnableError {
@@ -61,11 +62,14 @@ public extension OperationHandler {
             
             OperationHandler.handleWithOutputOperationHandlerResult(
                 handlerResult: handlerResult,
-                operationDelegate: operationDelegateToUse,
+                operationDelegate: operationDelegate,
                 request: request,
-                responseHandler: responseHandler)
+                responseHandler: responseHandler,
+                outputHandler: outputHandler)
         }
         
-        self.init(wrappedInputHandler)
+        self.init(inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
     }
 }

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
@@ -30,24 +30,24 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation
      */
-    public init<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
-            operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
+    public init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            inputProvider: @escaping (RequestType) throws -> InputType,
+            outputProvider: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
-            operationDelegate: OperationDelegateType? = nil) {
+            operationDelegate: OperationDelegateType)
+    where RequestType == OperationDelegateType.RequestType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
          * The wrapped input handler takes the provided operation handler and wraps it the responseHandler is
          * called to indicate success when the input handler's response handler is called. If the provided operation
          * provides an error, the responseHandler is called with that error.
          */
-        let wrappedInputHandler = { (input: InputType, request: OperationDelegateType.RequestType, context: ContextType,
-                                     defaultOperationDelegate: OperationDelegateType,
-                                     responseHandler: OperationDelegateType.ResponseHandlerType) in
-            let operationDelegateToUse = operationDelegate ?? defaultOperationDelegate
-
+        let wrappedInputHandler = { (input: InputType, request: RequestType, context: ContextType,
+                                     responseHandler: ResponseHandlerType) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>?
             do {
-                try operation(input, context) { error in
+                try outputProvider(input, context) { error in
                     let asyncHandlerResult: NoOutputOperationHandlerResult<ErrorType>
                     
                     if let error = error {
@@ -65,7 +65,7 @@ public extension OperationHandler {
                     
                     OperationHandler.handleNoOutputOperationHandlerResult(
                         handlerResult: asyncHandlerResult,
-                        operationDelegate: operationDelegateToUse,
+                        operationDelegate: operationDelegate,
                         request: request,
                         responseHandler: responseHandler)
                 }
@@ -84,12 +84,14 @@ public extension OperationHandler {
             if let handlerResult = handlerResult {
                 OperationHandler.handleNoOutputOperationHandlerResult(
                     handlerResult: handlerResult,
-                    operationDelegate: operationDelegateToUse,
+                    operationDelegate: operationDelegate,
                     request: request,
                     responseHandler: responseHandler)
             }
         }
         
-        self.init(wrappedInputHandler)
+        self.init(inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
     }
 }

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
@@ -24,15 +24,16 @@ public extension OperationHandler {
        returns a result with an empty body.
      
      - Parameters:
+        - inputProvider: function that obtains the input from the request.
         - operation: the handler method for the operation.
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
         - operationDelegate: optionally an operation-specific delegate to use when
-          handling the operation
+          handling the operation.
      */
     public init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             inputProvider: @escaping (RequestType) throws -> InputType,
-            outputProvider: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
+            operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestType == OperationDelegateType.RequestType,
@@ -47,7 +48,7 @@ public extension OperationHandler {
                                      responseHandler: ResponseHandlerType) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>?
             do {
-                try outputProvider(input, context) { error in
+                try operation(input, context) { error in
                     let asyncHandlerResult: NoOutputOperationHandlerResult<ErrorType>
                     
                     if let error = error {

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
@@ -24,16 +24,18 @@ public extension OperationHandler {
        returns a result body.
      
      - Parameters:
+        - inputProvider: function that obtains the input from the request.
         - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
         - operationDelegate: optionally an operation-specific delegate to use when
-          handling the operation
+          handling the operation.
      */
     public init<InputType: Validatable, OutputType: Validatable,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             inputProvider: @escaping (RequestType) throws -> InputType,
-            outputProvider: @escaping ((InputType, ContextType, @escaping
+            operation: @escaping ((InputType, ContextType, @escaping
                 (SmokeResult<OutputType>) -> Void) throws -> Void),
             outputHandler: @escaping ((RequestType, OutputType, ResponseHandlerType) -> Void),
             allowedErrors: [(ErrorType, Int)],
@@ -50,7 +52,7 @@ public extension OperationHandler {
                                      responseHandler: ResponseHandlerType) in
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>?
             do {
-                try outputProvider(input, context) { result in
+                try operation(input, context) { result in
                     let asyncHandlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
                     
                     switch result {

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
@@ -30,30 +30,32 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation
      */
-    public init<InputType: ValidatableCodable, OutputType: ValidatableCodable,
-            ErrorType: ErrorIdentifiableByDescription>(
-            operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
+    public init<InputType: Validatable, OutputType: Validatable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            inputProvider: @escaping (RequestType) throws -> InputType,
+            outputProvider: @escaping ((InputType, ContextType, @escaping
+                (SmokeResult<OutputType>) -> Void) throws -> Void),
+            outputHandler: @escaping ((RequestType, OutputType, ResponseHandlerType) -> Void),
             allowedErrors: [(ErrorType, Int)],
-            operationDelegate: OperationDelegateType? = nil) {
+            operationDelegate: OperationDelegateType)
+    where RequestType == OperationDelegateType.RequestType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
          * The wrapped input handler takes the provided operation handler and wraps it the responseHandler is
          * called with the result when the input handler's response handler is called. If the provided operation
          * provides an error, the responseHandler is called with that error.
          */
-        let wrappedInputHandler = { (input: InputType, request: OperationDelegateType.RequestType, context: ContextType,
-                                     defaultOperationDelegate: OperationDelegateType,
-                                     responseHandler: OperationDelegateType.ResponseHandlerType) in
-            let operationDelegateToUse = operationDelegate ?? defaultOperationDelegate
-            
+        let wrappedInputHandler = { (input: InputType, request: RequestType, context: ContextType,
+                                     responseHandler: ResponseHandlerType) in
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>?
             do {
-                try operation(input, context) { result in
+                try outputProvider(input, context) { result in
                     let asyncHandlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
                     
                     switch result {
-                    case .response(let output):
-                        asyncHandlerResult = .success(output)
+                    case .response(let result):
+                        asyncHandlerResult = .success(result)
                     case .error(let error):
                         if let smokeReturnableError = error as? SmokeReturnableError {
                             asyncHandlerResult = .smokeReturnableError(smokeReturnableError,
@@ -67,9 +69,10 @@ public extension OperationHandler {
                     
                     OperationHandler.handleWithOutputOperationHandlerResult(
                         handlerResult: asyncHandlerResult,
-                        operationDelegate: operationDelegateToUse,
+                        operationDelegate: operationDelegate,
                         request: request,
-                        responseHandler: responseHandler)
+                        responseHandler: responseHandler,
+                        outputHandler: outputHandler)
                 }
                 
                 // no immediate result
@@ -86,12 +89,15 @@ public extension OperationHandler {
             if let handlerResult = handlerResult {
                 OperationHandler.handleWithOutputOperationHandlerResult(
                     handlerResult: handlerResult,
-                    operationDelegate: operationDelegateToUse,
+                    operationDelegate: operationDelegate,
                     request: request,
-                    responseHandler: responseHandler)
+                    responseHandler: responseHandler,
+                    outputHandler: outputHandler)
             }
         }
         
-        self.init(wrappedInputHandler)
+        self.init(inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
+++ b/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
@@ -11,8 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  OperationDelegate.swift
-//  SmokeOperations
+//  HTTP1OperationDelegate.swift
+//  SmokeOperationsHTTP1
 //
 import Foundation
 import SmokeOperations

--- a/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
+++ b/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
@@ -1,0 +1,43 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  OperationDelegate.swift
+//  SmokeOperations
+//
+import Foundation
+import SmokeOperations
+
+/**
+ Delegate protocol for an operation that manages operation handling specific to
+ a transport protocol.
+ */
+public protocol HTTP1OperationDelegate: OperationDelegate {
+    /**
+     Function to retrieve an instance of the InputType from the request. Will throw an error
+     if an instance of InputType cannot be constructed from the request.
+     */
+    func getInputForOperation<InputType: Decodable>(request: RequestType) throws -> InputType
+    
+    /**
+     Function to handle a successful response from an operation.
+     
+     - Parameters:
+     - request: The original request corresponding to the operation. Can be used to determine how to
+     handle the response (such as requested response type).
+     - output: The instance of the OutputType to send as a response.
+     - responseHander: typically a response handler specific to the transport protocol being used.
+     */
+    func handleResponseForOperation<OutputType: Encodable>(request: RequestType,
+                                                           output: OutputType,
+                                                           responseHandler: ResponseHandlerType)
+}

--- a/Sources/SmokeOperationsHTTP1/JSONPayloadHTTP1OperationDelegate.swift
+++ b/Sources/SmokeOperationsHTTP1/JSONPayloadHTTP1OperationDelegate.swift
@@ -35,7 +35,7 @@ internal struct JSONErrorEncoder: ErrorEncoder {
  Struct conforming to the OperationDelegate protocol that handles operations from HTTP1 requests with JSON encoded
  request and response payloads.
  */
-public struct JSONPayloadHTTP1OperationDelegate: OperationDelegate {
+public struct JSONPayloadHTTP1OperationDelegate: HTTP1OperationDelegate {
     
     public init() {
         
@@ -47,10 +47,6 @@ public struct JSONPayloadHTTP1OperationDelegate: OperationDelegate {
         } else {
             throw SmokeOperationsError.validationError(reason: "Input body expected; none found.")
         }
-    }
-    
-    public func getOutputForOperation<OutputType: Encodable>(request: SmokeHTTP1Request, output: OutputType) throws -> Data? {
-        return try JSONEncoder.getFrameworkEncoder().encode(output)
     }
     
     public func handleResponseForOperation<OutputType>(request: SmokeHTTP1Request, output: OutputType,

--- a/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
@@ -14,7 +14,6 @@
 // OperationServerHTTP1RequestHandler.swift
 // SmokeOperationsHTTP1
 //
-
 import Foundation
 import SmokeOperations
 import NIOHTTP1
@@ -30,14 +29,13 @@ internal struct PingParameters {
  Implementation of the HttpRequestHandler protocol that handles an
  incoming Http request as an operation.
  */
-struct OperationServerHTTP1RequestHandler<ContextType, SelectorType, OperationDelegateType>: HTTP1RequestHandler
-        where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
-        SelectorType.OperationDelegateType == OperationDelegateType, OperationDelegateType.RequestType == SmokeHTTP1Request,
-        OperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler {
+struct OperationServerHTTP1RequestHandler<ContextType, SelectorType>: HTTP1RequestHandler
+    where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
+    SmokeHTTP1Request == SelectorType.DefaultOperationDelegateType.RequestType,
+HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType {
     let handlerSelector: SelectorType
     let context: ContextType
-    let defaultOperationDelegate: OperationDelegateType
-
+    
     public func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: HTTP1ResponseHandler) {
         // this is the ping url
         if requestHead.uri == PingParameters.uri {
@@ -48,29 +46,41 @@ struct OperationServerHTTP1RequestHandler<ContextType, SelectorType, OperationDe
             return
         }
         
-        let smokeHTTP1Request = SmokeHTTP1Request(httpRequestHead: requestHead, body: body)
-
+        let path = requestHead.uri
+        
         // get the handler to use
-        let handler: OperationHandler<ContextType, OperationDelegateType>
-                
+        let handler: OperationHandler<ContextType, SmokeHTTP1Request, HTTP1ResponseHandler>
+        let defaultOperationDelegate = handlerSelector.defaultOperationDelegate
+        
         do {
-            handler = try handlerSelector.getHandlerForOperation(requestHead)
+            handler = try handlerSelector.getHandlerForOperation(
+                path,
+                httpMethod: requestHead.method)
         } catch SmokeOperationsError.invalidOperation(reason: let reason) {
-            defaultOperationDelegate.handleResponseForInvalidOperation(request: smokeHTTP1Request,
-                                                                       message: reason,
-                                                                       responseHandler: responseHandler)
+            let smokeHTTP1Request = SmokeHTTP1Request(httpRequestHead: requestHead,
+                                                      body: body)
+            
+            defaultOperationDelegate.handleResponseForInvalidOperation(
+                request: smokeHTTP1Request,
+                message: reason,
+                responseHandler: responseHandler)
             return
         } catch {
             Log.error("Unexpected handler selection error: \(error))")
+            let smokeHTTP1Request = SmokeHTTP1Request(httpRequestHead: requestHead,
+                                                      body: body)
             
-            defaultOperationDelegate.handleResponseForInternalServerError(request: smokeHTTP1Request,
-                                                                          responseHandler: responseHandler)
+            defaultOperationDelegate.handleResponseForInternalServerError(
+                request: smokeHTTP1Request,
+                responseHandler: responseHandler)
             return
         }
         
+        let smokeHTTP1Request = SmokeHTTP1Request(httpRequestHead: requestHead,
+                                                  body: body)
+        
         // let it be handled
         handler.handle(smokeHTTP1Request, withContext: context,
-                       defaultOperationDelegate: defaultOperationDelegate,
                        responseHandler: responseHandler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
@@ -45,7 +45,7 @@ public extension SmokeHTTP1HandlerSelector {
         
         let handler = OperationHandler(
             inputProvider: inputProvider,
-            outputProvider: operation,
+            operation: operation,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
@@ -80,7 +80,7 @@ public extension SmokeHTTP1HandlerSelector {
             
             let handler = OperationHandler(
                 inputProvider: inputProvider,
-                outputProvider: operation,
+                operation: operation,
                 allowedErrors: allowedErrors,
                 operationDelegate: operationDelegate)
             

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
@@ -23,25 +23,67 @@ import NIOHTTP1
 public extension SmokeHTTP1HandlerSelector {
     /**
      Adds a handler for the specified uri and http method.
- 
+     
      - Parameters:
-        - uri: The uri to add the handler for.
-        - operation: the handler method for the operation.
-        - allowedErrors: the errors that can be serialized as responses
-          from the operation and their error codes.
-        - operationDelegate: optionally an operation-specific delegate to use when
-          handling the operation
+     - uri: The uri to add the handler for.
+     - operation: the handler method for the operation.
+     - allowedErrors: the errors that can be serialized as responses
+     from the operation and their error codes.
      */
     public mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> ()),
-        allowedErrors: [(ErrorType, Int)],
-        operationDelegate: OperationDelegateType? = nil) {
-            let handler = OperationHandler(operation: operation,
-                                           allowedErrors: allowedErrors,
-                                           operationDelegate: operationDelegate)
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                request: request)
+        }
+        
+        let handler = OperationHandler(
+            inputProvider: inputProvider,
+            outputProvider: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
         
         addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+     
+     - Parameters:
+     - uri: The uri to add the handler for.
+     - operation: the handler method for the operation.
+     - allowedErrors: the errors that can be serialized as responses
+     from the operation and their error codes.
+     - operationDelegate: an operation-specific delegate to use when
+     handling the operation
+     */
+    public mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ uri: String,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    request: request)
+            }
+            
+            let handler = OperationHandler(
+                inputProvider: inputProvider,
+                outputProvider: operation,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
@@ -54,7 +54,7 @@ public extension SmokeHTTP1HandlerSelector {
         
         let handler = OperationHandler(
             inputProvider: inputProvider,
-            outputProvider: operation,
+            operation: operation,
             outputHandler: outputHandler,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
@@ -98,7 +98,7 @@ public extension SmokeHTTP1HandlerSelector {
             
             let handler = OperationHandler(
                 inputProvider: inputProvider,
-                outputProvider: operation,
+                operation: operation,
                 outputHandler: outputHandler,
                 allowedErrors: allowedErrors,
                 operationDelegate: operationDelegate)

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
@@ -23,26 +23,86 @@ import NIOHTTP1
 public extension SmokeHTTP1HandlerSelector {
     /**
      Adds a handler for the specified uri and http method.
- 
+     
      - Parameters:
-        - uri: The uri to add the handler for.
-        - operation: the handler method for the operation.
-        - allowedErrors: the errors that can be serialized as responses
-          from the operation and their error codes.
-        - operationDelegate: optionally an operation-specific delegate to use when
-          handling the operation
+     - uri: The uri to add the handler for.
+     - operation: the handler method for the operation.
+     - allowedErrors: the errors that can be serialized as responses
+     from the operation and their error codes.
      */
     public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
-            ErrorType: ErrorIdentifiableByDescription>(
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ uri: String,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                request: request)
+        }
+        
+        func outputHandler(request: DefaultOperationDelegateType.RequestType,
+                           output: OutputType,
+                           responseHandler: DefaultOperationDelegateType.ResponseHandlerType) {
+            delegateToUse.handleResponseForOperation(request: request,
+                                                     output: output,
+                                                     responseHandler: responseHandler)
+        }
+        
+        let handler = OperationHandler(
+            inputProvider: inputProvider,
+            outputProvider: operation,
+            outputHandler: outputHandler,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+     
+     - Parameters:
+     - uri: The uri to add the handler for.
+     - operation: the handler method for the operation.
+     - allowedErrors: the errors that can be serialized as responses
+     from the operation and their error codes.
+     - operationDelegate: an operation-specific delegate to use when
+     handling the operation
+     */
+    public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)],
-        operationDelegate: OperationDelegateType? = nil) {
-            let handler = OperationHandler(operation: operation,
-                                           allowedErrors: allowedErrors,
-                                           operationDelegate: operationDelegate)
-        
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    request: request)
+            }
+            
+            func outputHandler(request: OperationDelegateType.RequestType,
+                               output: OutputType,
+                               responseHandler: OperationDelegateType.ResponseHandlerType) {
+                operationDelegate.handleResponseForOperation(request: request,
+                                                             output: output,
+                                                             responseHandler: responseHandler)
+            }
+            
+            let handler = OperationHandler(
+                inputProvider: inputProvider,
+                outputProvider: operation,
+                outputHandler: outputHandler,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
@@ -49,7 +49,7 @@ public extension SmokeHTTP1HandlerSelector {
         
         let handler = OperationHandler(
             inputProvider: inputProvider,
-            outputProvider: operation,
+            operation: operation,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
@@ -88,7 +88,7 @@ public extension SmokeHTTP1HandlerSelector {
             
             let handler = OperationHandler(
                 inputProvider: inputProvider,
-                outputProvider: operation,
+                operation: operation,
                 allowedErrors: allowedErrors,
                 operationDelegate: operationDelegate)
             

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
@@ -23,25 +23,75 @@ import NIOHTTP1
 public extension SmokeHTTP1HandlerSelector {
     /**
      Adds a handler for the specified uri and http method.
- 
+     
      - Parameters:
-        - uri: The uri to add the handler for.
-        - operation: the handler method for the operation.
-        - allowedErrors: the errors that can be serialized as responses
-          from the operation and their error codes.
-        - operationDelegate: optionally an operation-specific delegate to use when
-          handling the operation
+     - uri: The uri to add the handler for.
+     - operation: the handler method for the operation.
+     - allowedErrors: the errors that can be serialized as responses
+     from the operation and their error codes.
      */
     public mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
-        allowedErrors: [(ErrorType, Int)],
-        operationDelegate: OperationDelegateType? = nil) {
-            let handler = OperationHandler(operation: operation,
-                                           allowedErrors: allowedErrors,
-                                           operationDelegate: operationDelegate)
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        func outputProvider(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {
+            try operation(input, context, completion)
+        }
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                request: request)
+        }
+        
+        let handler = OperationHandler(
+            inputProvider: inputProvider,
+            outputProvider: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
         
         addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+     
+     - Parameters:
+     - uri: The uri to add the handler for.
+     - operation: the handler method for the operation.
+     - allowedErrors: the errors that can be serialized as responses
+     from the operation and their error codes.
+     - operationDelegate: an operation-specific delegate to use when
+     handling the operation
+     */
+    public mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ uri: String,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func outputProvider(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {
+                try operation(input, context, completion)
+            }
+            
+            func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    request: request)
+            }
+            
+            let handler = OperationHandler(
+                inputProvider: inputProvider,
+                outputProvider: operation,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
@@ -54,7 +54,7 @@ public extension SmokeHTTP1HandlerSelector {
         
         let handler = OperationHandler(
             inputProvider: inputProvider,
-            outputProvider: operation,
+            operation: operation,
             outputHandler: outputHandler,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
@@ -98,7 +98,7 @@ public extension SmokeHTTP1HandlerSelector {
             
             let handler = OperationHandler(
                 inputProvider: inputProvider,
-                outputProvider: operation,
+                operation: operation,
                 outputHandler: outputHandler,
                 allowedErrors: allowedErrors,
                 operationDelegate: operationDelegate)

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
@@ -23,26 +23,86 @@ import NIOHTTP1
 public extension SmokeHTTP1HandlerSelector {
     /**
      Adds a handler for the specified uri and http method.
- 
+     
      - Parameters:
-        - uri: The uri to add the handler for.
-        - operation: the handler method for the operation.
-        - allowedErrors: the errors that can be serialized as responses
-          from the operation and their error codes.
-        - operationDelegate: optionally an operation-specific delegate to use when
-          handling the operation
+     - uri: The uri to add the handler for.
+     - operation: the handler method for the operation.
+     - allowedErrors: the errors that can be serialized as responses
+     from the operation and their error codes.
      */
     public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
-            ErrorType: ErrorIdentifiableByDescription>(
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ uri: String,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                request: request)
+        }
+        
+        func outputHandler(request: DefaultOperationDelegateType.RequestType,
+                           output: OutputType,
+                           responseHandler: DefaultOperationDelegateType.ResponseHandlerType) {
+            delegateToUse.handleResponseForOperation(request: request,
+                                                     output: output,
+                                                     responseHandler: responseHandler)
+        }
+        
+        let handler = OperationHandler(
+            inputProvider: inputProvider,
+            outputProvider: operation,
+            outputHandler: outputHandler,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+     
+     - Parameters:
+     - uri: The uri to add the handler for.
+     - operation: the handler method for the operation.
+     - allowedErrors: the errors that can be serialized as responses
+     from the operation and their error codes.
+     - operationDelegate: an operation-specific delegate to use when
+     handling the operation
+     */
+    public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
-        operationDelegate: OperationDelegateType? = nil) {
-            let handler = OperationHandler(operation: operation,
-                                           allowedErrors: allowedErrors,
-                                           operationDelegate: operationDelegate)
-        
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    request: request)
+            }
+            
+            func outputHandler(request: OperationDelegateType.RequestType,
+                               output: OutputType,
+                               responseHandler: OperationDelegateType.ResponseHandlerType) {
+                operationDelegate.handleResponseForOperation(request: request,
+                                                             output: output,
+                                                             responseHandler: responseHandler)
+            }
+            
+            let handler = OperationHandler(
+                inputProvider: inputProvider,
+                outputProvider: operation,
+                outputHandler: outputHandler,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
@@ -14,7 +14,6 @@
 //  SmokeHTTP1HandlerSelector.swift
 //  SmokeOperationsHTTP1
 //
-
 import Foundation
 import SmokeOperations
 import NIOHTTP1
@@ -25,26 +24,34 @@ import NIOHTTP1
  */
 public protocol SmokeHTTP1HandlerSelector {
     associatedtype ContextType
-    associatedtype OperationDelegateType: OperationDelegate
+    associatedtype DefaultOperationDelegateType: HTTP1OperationDelegate
+    
+    /// Get the instance of the Default OperationDelegate type
+    var defaultOperationDelegate: DefaultOperationDelegateType { get }
     
     /**
      Gets the handler to use for an operation with the provided http request
      head.
- 
+     
      - Parameters
-        - requestHead: the request head of an incoming operation.
+     - requestHead: the request head of an incoming operation.
      */
-    func getHandlerForOperation(_ requestHead: HTTPRequestHead) throws -> OperationHandler<ContextType, OperationDelegateType>
+    func getHandlerForOperation(_ uri: String, httpMethod: HTTPMethod) throws
+        -> OperationHandler<ContextType,
+        DefaultOperationDelegateType.RequestType,
+        DefaultOperationDelegateType.ResponseHandlerType>
     
     /**
      Adds a handler for the specified uri and http method.
- 
+     
      - Parameters:
-        - uri: The uri to add the handler for.
-        - httpMethod: the http method to add the handler for.
-        - handler: the handler to add.
+     - uri: The uri to add the handler for.
+     - httpMethod: the http method to add the handler for.
+     - handler: the handler to add.
      */
     mutating func addHandlerForUri(_ uri: String,
                                    httpMethod: HTTPMethod,
-                                   handler: OperationHandler<ContextType, OperationDelegateType>)
+                                   handler: OperationHandler<ContextType,
+        DefaultOperationDelegateType.RequestType,
+        DefaultOperationDelegateType.ResponseHandlerType>)
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -14,40 +14,39 @@
 // SmokeHTTP1Server+startAsOperationServer.swift
 // SmokeOperationsHTTP1
 //
-
 import Foundation
 import SmokeHTTP1
 import NIOHTTP1
 import LoggerAPI
+import SmokeOperations
 
 public extension SmokeHTTP1Server {
     
     /**
      Start the Http Server to handle operations.
- 
+     
      - Parameters:
-        - handlerSelector: the selector that will provide an operation
-          handler for a operation request
-        - context: the context to pass to operation handlers.
+     - handlerSelector: the selector that will provide an operation
+     handler for a operation request
+     - context: the context to pass to operation handlers.
      */
-    public static func startAsOperationServer<ContextType, SelectorType, OperationDelegateType>(
+    public static func startAsOperationServer<ContextType, SelectorType>(
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
-        defaultOperationDelegate: OperationDelegateType,
         andPort port: Int = ServerDefaults.defaultPort,
         invocationStrategy: InvocationStrategy = GlobalDispatchQueueInvocationStrategy()) throws
         where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
-        SelectorType.OperationDelegateType == OperationDelegateType, OperationDelegateType.RequestType == SmokeHTTP1Request,
-        OperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler {
-            let handler = OperationServerHTTP1RequestHandler(handlerSelector: handlerSelector,
-                                                             context: context,
-                                                             defaultOperationDelegate: defaultOperationDelegate)
+        SelectorType.DefaultOperationDelegateType.RequestType == SmokeHTTP1Request,
+        SelectorType.DefaultOperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler {
+            let handler = OperationServerHTTP1RequestHandler(
+                handlerSelector: handlerSelector,
+                context: context)
             let server = SmokeHTTP1Server(handler: handler,
                                           port: port,
                                           invocationStrategy: invocationStrategy)
             
             Log.info("Server starting on port \(port)...")
-        
+            
             try server.start()
             
             Log.info("Server started on port \(port)...")

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
@@ -59,42 +59,42 @@ func handleBadOperationAsyncWithThrow(input: ExampleInput, context: ExampleConte
 }
 
 fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate> = {
-    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate>()
+    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate>(
+        defaultOperationDelegate: JSONPayloadHTTP1OperationDelegate())
     newHandlerSelector.addHandlerForUri("exampleoperation", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleExampleOperationAsync,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleExampleOperationAsync,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("examplegetoperation", httpMethod: .GET,
-                                        handler: OperationHandler(operation: handleExampleOperationAsync,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleExampleOperationAsync,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("examplenobodyoperation", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleExampleOperationVoidAsync,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleExampleOperationVoidAsync,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("badoperationvoidresponse", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleBadOperationVoidAsync,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleBadOperationVoidAsync,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("badoperationvoidresponsewiththrow", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleBadOperationVoidAsyncWithThrow,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleBadOperationVoidAsyncWithThrow,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("badoperation", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleBadOperationAsync,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleBadOperationAsync,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("badoperationwiththrow", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleBadOperationAsync,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleBadOperationAsync,
+                                        allowedErrors: allowedErrors)
     
     return newHandlerSelector
 }()
 
 private func verifyPathOutput(uri: String, body: Data) -> OperationResponse {
     let handler = OperationServerHTTP1RequestHandler(handlerSelector: handlerSelector,
-                                                     context: ExampleContext(),
-                                                     defaultOperationDelegate: JSONPayloadHTTP1OperationDelegate())
+                                                     context: ExampleContext())
     
     let httpRequestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
                                           method: .POST,

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
@@ -39,34 +39,34 @@ func handleBadOperation(input: ExampleInput, context: ExampleContext) throws -> 
 }
 
 fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate> = {
-    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate>()
+    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate>(
+        defaultOperationDelegate: JSONPayloadHTTP1OperationDelegate())
     newHandlerSelector.addHandlerForUri("exampleoperation", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleExampleOperation,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleExampleOperation,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("examplegetoperation", httpMethod: .GET,
-                                        handler: OperationHandler(operation: handleExampleOperation,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleExampleOperation,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("examplenobodyoperation", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleExampleOperationVoid,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleExampleOperationVoid,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("badoperation", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleBadOperation,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleBadOperation,
+                                        allowedErrors: allowedErrors)
     
     newHandlerSelector.addHandlerForUri("badoperationvoidresponse", httpMethod: .POST,
-                                        handler: OperationHandler(operation: handleBadOperationVoid,
-                                                                  allowedErrors: allowedErrors))
+                                        operation: handleBadOperationVoid,
+                                        allowedErrors: allowedErrors)
     
     return newHandlerSelector
 }()
 
 private func verifyPathOutput(uri: String, body: Data) -> OperationResponse {
     let handler = OperationServerHTTP1RequestHandler(handlerSelector: handlerSelector,
-                                                     context: ExampleContext(),
-                                                     defaultOperationDelegate: JSONPayloadHTTP1OperationDelegate())
+                                                     context: ExampleContext())
     
     let httpRequestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
                                           method: .POST,


### PR DESCRIPTION
Fix the use of the generic OperationDelegateType to allow the default delegate type and handler-specific delegate types to be different. Remove Codable constraint for inputs and outputs in the SmokeOperations library.

*Issue #, if available:* #5 

*Description of changes:*
* Remove the `Codable` constraint for input and outputs in the SmokeOperations library, passing in `inputProvider` and `outputHandler` functions to handle transforming inputs and outputs. Move these transformation protocol requirements from `OperationDelegate` to (for HTTP1) `HTTP1OperationDelegate`. This paves the way to introduce HTTP1-specific input and output types to handle this transformation for the components of a HTTP1 request and response.
* Remove the `OperationDelegate` generic constraint from `OperationHandler`, moving this constraint to the initialiser. This allows the `OperationDelegate` of each handler to be type-erased in line with the other type-erasure of `OperationDelegate` (input type etc). Previously this caused an issue where the `OperationDelegate` of each handler had to be the same type as the default delegate. Knowledge and storage of the default delegate has moved from `OperationServerHTTP1RequestHandler` (passed in as part of the `SmokeHTTP1Server+startAsOperationServer` call) to `SmokeHTTP1HandlerSelector` (passed in as part of the initialisation of `StandardSmokeHTTP1HandlerSelector`). The handler selector now has `addHandlerForUri` overrides that determine if the default or a custom operation handler (to a type specific to that handler and type-erased as part of `OperationHandler`) is to be used. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
