### PR TITLE
HTTP1 operation input and output

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,39 @@
         }
       },
       {
+        "package": "SmokeHTTP",
+        "repositoryURL": "https://github.com/amzn/smoke-http.git",
+        "state": {
+          "branch": null,
+          "revision": "01718910a341f2f53bdaa1cb3021ab98d598539d",
+          "version": "0.6.2"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
           "revision": "03c541a24dd0558c942b15d8464eb75d70a921c4",
           "version": "1.12.1"
+        }
+      },
+      {
+        "package": "swift-nio-ssl",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
+        "state": {
+          "branch": null,
+          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
+          "version": "1.4.0"
+        }
+      },
+      {
+        "package": "swift-nio-ssl-support",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl-support.git",
+        "state": {
+          "branch": null,
+          "revision": "c02eec4e0e6d351cd092938cf44195a8e669f555",
+          "version": "1.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.0.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "0.6.2"),
     ],
     targets: [
         .target(
@@ -29,7 +30,8 @@ let package = Package(
             dependencies: ["LoggerAPI"]),
         .target(
             name: "SmokeOperationsHTTP1",
-            dependencies: ["SmokeOperations", "SmokeHTTP1"]),
+            dependencies: ["SmokeOperations", "SmokeHTTP1", "QueryCoding",
+                           "HTTPPathCoding", "HTTPHeadersCoding"]),
         .testTarget(
             name: "SmokeOperationsHTTP1Tests",
             dependencies: ["SmokeOperationsHTTP1"]),

--- a/Sources/SmokeOperationsHTTP1/AdditionalHeadersOperationHTTPOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/AdditionalHeadersOperationHTTPOutput.swift
@@ -21,7 +21,7 @@ public struct AdditionalHeadersOperationHTTPOutput<AdditionalHeadersType: Encoda
     public let bodyEncodable: AdditionalHeadersType?
     public let additionalHeadersEncodable: AdditionalHeadersType?
     
-    public init(additionalHeadersEncodable: AdditionalHeadersType?) {
+    public init(additionalHeadersEncodable: AdditionalHeadersType) {
         self.bodyEncodable = nil
         self.additionalHeadersEncodable = additionalHeadersEncodable
     }

--- a/Sources/SmokeOperationsHTTP1/AdditionalHeadersOperationHTTPOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/AdditionalHeadersOperationHTTPOutput.swift
@@ -11,21 +11,18 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  SmokeHTTP1Request.swift
+//  AdditionalHeadersOperationHTTPOutput.swift
 //  SmokeOperationsHTTP1
 //
 
 import Foundation
-import NIOHTTP1
-import SmokeHTTP1
-import ShapeCoding
 
-/**
- Structure representing an incoming HTTP1 request.
- */
-public struct SmokeHTTP1Request {
-    public let httpRequestHead: HTTPRequestHead
-    public let query: String
-    public let pathShape: Shape
-    public let body: Data?
+public struct AdditionalHeadersOperationHTTPOutput<AdditionalHeadersType: Encodable>: OperationHTTP1OutputProtocol {
+    public let bodyEncodable: AdditionalHeadersType?
+    public let additionalHeadersEncodable: AdditionalHeadersType?
+    
+    public init(additionalHeadersEncodable: AdditionalHeadersType?) {
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = additionalHeadersEncodable
+    }
 }

--- a/Sources/SmokeOperationsHTTP1/BodyOperationHTTPInput.swift
+++ b/Sources/SmokeOperationsHTTP1/BodyOperationHTTPInput.swift
@@ -1,0 +1,45 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  BodyOperationHTTPInput.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+
+/**
+ Implementation of the OperationHTTP1InputProtocol that only decodes
+ the HTTP body.
+ */
+public struct BodyOperationHTTPInput<BodyType: Decodable>: OperationHTTP1InputProtocol {
+    // This struct doesn't use these types but we must provide a
+    // concrete type to satify the protocol
+    public typealias QueryType = String
+    public typealias PathType = String
+    public typealias HeadersType = String
+    
+    public let body: BodyType
+    
+    public init(body: BodyType) {
+        self.body = body
+    }
+    
+    public static func compose(queryDecodableProvider: () throws -> String,
+                               pathDecodableProvider: () throws -> String,
+                               bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> String) throws -> BodyOperationHTTPInput {
+        let body = try bodyDecodableProvider()
+        
+        return .init(body: body)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/BodyOperationHTTPOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/BodyOperationHTTPOutput.swift
@@ -11,21 +11,18 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  SmokeHTTP1Request.swift
+//  BodyOperationHTTPOutput.swift
 //  SmokeOperationsHTTP1
 //
 
 import Foundation
-import NIOHTTP1
-import SmokeHTTP1
-import ShapeCoding
 
-/**
- Structure representing an incoming HTTP1 request.
- */
-public struct SmokeHTTP1Request {
-    public let httpRequestHead: HTTPRequestHead
-    public let query: String
-    public let pathShape: Shape
-    public let body: Data?
+public struct BodyOperationHTTPOutput<BodyType: Encodable>: OperationHTTP1OutputProtocol {
+    public let bodyEncodable: BodyType?
+    public let additionalHeadersEncodable: BodyType?
+    
+    public init(bodyEncodable: BodyType?) {
+        self.bodyEncodable = bodyEncodable
+        self.additionalHeadersEncodable = nil
+    }
 }

--- a/Sources/SmokeOperationsHTTP1/BodyOperationHTTPOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/BodyOperationHTTPOutput.swift
@@ -21,7 +21,7 @@ public struct BodyOperationHTTPOutput<BodyType: Encodable>: OperationHTTP1Output
     public let bodyEncodable: BodyType?
     public let additionalHeadersEncodable: BodyType?
     
-    public init(bodyEncodable: BodyType?) {
+    public init(bodyEncodable: BodyType) {
         self.bodyEncodable = bodyEncodable
         self.additionalHeadersEncodable = nil
     }

--- a/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
+++ b/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
@@ -14,8 +14,21 @@
 //  HTTP1OperationDelegate.swift
 //  SmokeOperationsHTTP1
 //
+
 import Foundation
 import SmokeOperations
+
+public enum OperationInputHTTPLocation {
+    case body
+    case query
+    case path
+    case headers
+}
+
+public enum OperationOutputHTTPLocation {
+    case body
+    case headers
+}
 
 /**
  Delegate protocol for an operation that manages operation handling specific to
@@ -26,18 +39,40 @@ public protocol HTTP1OperationDelegate: OperationDelegate {
      Function to retrieve an instance of the InputType from the request. Will throw an error
      if an instance of InputType cannot be constructed from the request.
      */
-    func getInputForOperation<InputType: Decodable>(request: RequestType) throws -> InputType
+    func getInputForOperation<InputType: OperationHTTP1InputProtocol>(request: RequestType) throws -> InputType
+    
+    /**
+     Function to retrieve an instance of the InputType from the request. Will throw an error
+     if an instance of InputType cannot be constructed from the request.
+     */
+    func getInputForOperation<InputType: Decodable>(request: RequestType,
+                                                    location: OperationInputHTTPLocation) throws -> InputType
     
     /**
      Function to handle a successful response from an operation.
-     
+ 
      - Parameters:
-     - request: The original request corresponding to the operation. Can be used to determine how to
-     handle the response (such as requested response type).
-     - output: The instance of the OutputType to send as a response.
-     - responseHander: typically a response handler specific to the transport protocol being used.
+        - request: The original request corresponding to the operation. Can be used to determine how to
+          handle the response (such as requested response type).
+        - output: The instance of the OutputType to send as a response.
+        - responseHander: typically a response handler specific to the transport protocol being used.
+     */
+    func handleResponseForOperation<OutputType: OperationHTTP1OutputProtocol>(
+        request: RequestType,
+        output: OutputType,
+        responseHandler: ResponseHandlerType)
+    
+    /**
+     Function to handle a successful response from an operation.
+ 
+     - Parameters:
+        - request: The original request corresponding to the operation. Can be used to determine how to
+          handle the response (such as requested response type).
+        - output: The instance of the OutputType to send as a response.
+        - responseHander: typically a response handler specific to the transport protocol being used.
      */
     func handleResponseForOperation<OutputType: Encodable>(request: RequestType,
+                                                           location: OperationOutputHTTPLocation,
                                                            output: OutputType,
                                                            responseHandler: ResponseHandlerType)
 }

--- a/Sources/SmokeOperationsHTTP1/HeadersOperationHTTPInput.swift
+++ b/Sources/SmokeOperationsHTTP1/HeadersOperationHTTPInput.swift
@@ -1,0 +1,45 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HeadersOperationHTTPInput.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+
+/**
+ Implementation of the OperationHTTP1InputProtocol that only decodes
+ the HTTP path.
+ */
+public struct HeadersOperationHTTPInput<HeadersType: Decodable>: OperationHTTP1InputProtocol {
+    // This struct doesn't use these types but we must provide a
+    // concrete type to satify the protocol
+    public typealias QueryType = String
+    public typealias BodyType = String
+    public typealias PathType = String
+    
+    public let headers: HeadersType
+    
+    public init(headers: HeadersType) {
+        self.headers = headers
+    }
+    
+    public static func compose(queryDecodableProvider: () throws -> String,
+                               pathDecodableProvider: () throws -> String,
+                               bodyDecodableProvider: () throws -> String,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> HeadersOperationHTTPInput {
+        let headers = try headersDecodableProvider()
+        
+        return .init(headers: headers)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/Operation1HTTPOutputProtocol.swift
+++ b/Sources/SmokeOperationsHTTP1/Operation1HTTPOutputProtocol.swift
@@ -11,21 +11,25 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  SmokeHTTP1Request.swift
+//  OperationHTTP1OutputProtocol.swift
 //  SmokeOperationsHTTP1
 //
 
 import Foundation
-import NIOHTTP1
-import SmokeHTTP1
-import ShapeCoding
+import SmokeOperations
 
 /**
- Structure representing an incoming HTTP1 request.
+ A protocol that represents the output from an operation to be
+ send as a HTTP response.
  */
-public struct SmokeHTTP1Request {
-    public let httpRequestHead: HTTPRequestHead
-    public let query: String
-    public let pathShape: Shape
-    public let body: Data?
+public protocol OperationHTTP1OutputProtocol {
+    associatedtype BodyType: Encodable
+    associatedtype AdditionalHeadersType: Encodable
+
+    /// An instance of a type that is encodable to a body
+    var bodyEncodable: BodyType? { get }
+    /// An instance of a type that is encodable to additional headers
+    var additionalHeadersEncodable: AdditionalHeadersType? { get }
 }
+
+public typealias ValidatableOperationHTTP1OutputProtocol = Validatable & OperationHTTP1OutputProtocol

--- a/Sources/SmokeOperationsHTTP1/OperationHTTP1InputProtocol.swift
+++ b/Sources/SmokeOperationsHTTP1/OperationHTTP1InputProtocol.swift
@@ -1,0 +1,44 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  OperationHTTP1InputProtocol.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+
+/**
+ A protocol that represents the input to an operation from a HTTP request.
+ */
+public protocol OperationHTTP1InputProtocol {
+    associatedtype QueryType: Decodable
+    associatedtype PathType: Decodable
+    associatedtype BodyType: Decodable
+    associatedtype HeadersType: Decodable
+    
+    /**
+     Composes an instance from its constituent Decodable parts.
+     May return one of its constituent parts if of a compatible type.
+ 
+     - Parameters:
+        - bodyDecodableProvider: provider for the decoded body for this instance.
+        - headersDecodableProvider: provider for the decoded headers for this instance.
+     */
+    static func compose(queryDecodableProvider: () throws -> QueryType,
+                        pathDecodableProvider: () throws -> PathType,
+                        bodyDecodableProvider: () throws -> BodyType,
+                        headersDecodableProvider: () throws -> HeadersType) throws -> Self
+}
+
+public typealias ValidatableOperationHTTP1InputProtocol = Validatable & OperationHTTP1InputProtocol

--- a/Sources/SmokeOperationsHTTP1/OperationHTTP1InputProtocol.swift
+++ b/Sources/SmokeOperationsHTTP1/OperationHTTP1InputProtocol.swift
@@ -32,6 +32,8 @@ public protocol OperationHTTP1InputProtocol {
      May return one of its constituent parts if of a compatible type.
  
      - Parameters:
+        - queryDecodableProvider: provider for the decoded query for this instance.
+        - pathDecodableProvider: provider for the decoded http path for this instance.
         - bodyDecodableProvider: provider for the decoded body for this instance.
         - headersDecodableProvider: provider for the decoded headers for this instance.
      */

--- a/Sources/SmokeOperationsHTTP1/PathOperationHTTPInput.swift
+++ b/Sources/SmokeOperationsHTTP1/PathOperationHTTPInput.swift
@@ -1,0 +1,45 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  PathOperationHTTPInput.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+
+/**
+ Implementation of the OperationHTTP1InputProtocol that only decodes
+ the HTTP path.
+ */
+public struct PathOperationHTTPInput<PathType: Decodable>: OperationHTTP1InputProtocol {
+    // This struct doesn't use these types but we must provide a
+    // concrete type to satify the protocol
+    public typealias QueryType = String
+    public typealias BodyType = String
+    public typealias HeadersType = String
+    
+    public let path: PathType
+    
+    public init(path: PathType) {
+        self.path = path
+    }
+    
+    public static func compose(queryDecodableProvider: () throws -> String,
+                               pathDecodableProvider: () throws -> PathType,
+                               bodyDecodableProvider: () throws -> String,
+                               headersDecodableProvider: () throws -> String) throws -> PathOperationHTTPInput {
+        let path = try pathDecodableProvider()
+        
+        return .init(path: path)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/QueryOperationHTTPInput.swift
+++ b/Sources/SmokeOperationsHTTP1/QueryOperationHTTPInput.swift
@@ -1,0 +1,45 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  QueryOperationHTTPInput.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+
+/**
+ Implementation of the OperationHTTP1InputProtocol that only decodes
+ the HTTP query.
+ */
+public struct QueryOperationHTTPInput<QueryType: Decodable>: OperationHTTP1InputProtocol {
+    // This struct doesn't use these types but we must provide a
+    // concrete type to satify the protocol
+    public typealias BodyType = String
+    public typealias PathType = String
+    public typealias HeadersType = String
+    
+    public let query: QueryType
+    
+    public init(query: QueryType) {
+        self.query = query
+    }
+    
+    public static func compose(queryDecodableProvider: () throws -> QueryType,
+                               pathDecodableProvider: () throws -> String,
+                               bodyDecodableProvider: () throws -> String,
+                               headersDecodableProvider: () throws -> String) throws -> QueryOperationHTTPInput {
+        let query = try queryDecodableProvider()
+        
+        return .init(query: query)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
@@ -23,31 +23,35 @@ import NIOHTTP1
 public extension SmokeHTTP1HandlerSelector {
     /**
      Adds a handler for the specified uri and http method.
-     
+ 
      - Parameters:
-     - uri: The uri to add the handler for.
-     - operation: the handler method for the operation.
-     - allowedErrors: the errors that can be serialized as responses
-     from the operation and their error codes.
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
      */
     public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> OutputType),
-        allowedErrors: [(ErrorType, Int)]) {
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation) {
         
         // don't capture self
         let delegateToUse = defaultOperationDelegate
         func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
             return try delegateToUse.getInputForOperation(
-                request: request)
+                request: request,
+                location: inputLocation)
         }
         
         func outputHandler(request: DefaultOperationDelegateType.RequestType,
                            output: OutputType,
                            responseHandler: DefaultOperationDelegateType.ResponseHandlerType) {
             delegateToUse.handleResponseForOperation(request: request,
+                                                     location: outputLocation,
                                                      output: output,
                                                      responseHandler: responseHandler)
         }
@@ -64,14 +68,14 @@ public extension SmokeHTTP1HandlerSelector {
     
     /**
      Adds a handler for the specified uri and http method.
-     
+ 
      - Parameters:
-     - uri: The uri to add the handler for.
-     - operation: the handler method for the operation.
-     - allowedErrors: the errors that can be serialized as responses
-     from the operation and their error codes.
-     - operationDelegate: an operation-specific delegate to use when
-     handling the operation
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
      */
     public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
@@ -79,19 +83,23 @@ public extension SmokeHTTP1HandlerSelector {
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
                 return try operationDelegate.getInputForOperation(
-                    request: request)
+                    request: request,
+                    location: inputLocation)
             }
             
             func outputHandler(request: OperationDelegateType.RequestType,
                                output: OutputType,
                                responseHandler: OperationDelegateType.ResponseHandlerType) {
                 operationDelegate.handleResponseForOperation(request: request,
+                                                             location: outputLocation,
                                                              output: output,
                                                              responseHandler: responseHandler)
             }
@@ -104,5 +112,64 @@ public extension SmokeHTTP1HandlerSelector {
                 operationDelegate: operationDelegate)
             
             addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+        OutputType: ValidatableOperationHTTP1OutputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ uri: String,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: defaultOperationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+        OutputType: ValidatableOperationHTTP1OutputProtocol,
+        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ uri: String,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: operationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
@@ -23,31 +23,35 @@ import NIOHTTP1
 public extension SmokeHTTP1HandlerSelector {
     /**
      Adds a handler for the specified uri and http method.
-     
+ 
      - Parameters:
-     - uri: The uri to add the handler for.
-     - operation: the handler method for the operation.
-     - allowedErrors: the errors that can be serialized as responses
-     from the operation and their error codes.
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
      */
     public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
-        ErrorType: ErrorIdentifiableByDescription>(
+            ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
-        allowedErrors: [(ErrorType, Int)]) {
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation) {
         
         // don't capture self
         let delegateToUse = defaultOperationDelegate
         func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
             return try delegateToUse.getInputForOperation(
-                request: request)
+                request: request,
+                location: inputLocation)
         }
         
         func outputHandler(request: DefaultOperationDelegateType.RequestType,
                            output: OutputType,
                            responseHandler: DefaultOperationDelegateType.ResponseHandlerType) {
             delegateToUse.handleResponseForOperation(request: request,
+                                                     location: outputLocation,
                                                      output: output,
                                                      responseHandler: responseHandler)
         }
@@ -64,34 +68,38 @@ public extension SmokeHTTP1HandlerSelector {
     
     /**
      Adds a handler for the specified uri and http method.
-     
+ 
      - Parameters:
-     - uri: The uri to add the handler for.
-     - operation: the handler method for the operation.
-     - allowedErrors: the errors that can be serialized as responses
-     from the operation and their error codes.
-     - operationDelegate: an operation-specific delegate to use when
-     handling the operation
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
      */
     public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
-        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
                 return try operationDelegate.getInputForOperation(
-                    request: request)
+                    request: request,
+                    location: inputLocation)
             }
             
             func outputHandler(request: OperationDelegateType.RequestType,
                                output: OutputType,
                                responseHandler: OperationDelegateType.ResponseHandlerType) {
                 operationDelegate.handleResponseForOperation(request: request,
+                                                             location: outputLocation,
                                                              output: output,
                                                              responseHandler: responseHandler)
             }
@@ -104,5 +112,62 @@ public extension SmokeHTTP1HandlerSelector {
                 operationDelegate: operationDelegate)
             
             addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription>(
+        _ uri: String,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: defaultOperationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ uri: String,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: operationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
@@ -17,6 +17,7 @@
 import Foundation
 import SmokeOperations
 import NIOHTTP1
+import ShapeCoding
 
 /**
  Protocol that provides the handler to use for an operation using the
@@ -32,26 +33,26 @@ public protocol SmokeHTTP1HandlerSelector {
     /**
      Gets the handler to use for an operation with the provided http request
      head.
-     
+ 
      - Parameters
-     - requestHead: the request head of an incoming operation.
+        - requestHead: the request head of an incoming operation.
      */
     func getHandlerForOperation(_ uri: String, httpMethod: HTTPMethod) throws
-        -> OperationHandler<ContextType,
-        DefaultOperationDelegateType.RequestType,
-        DefaultOperationDelegateType.ResponseHandlerType>
+        -> (OperationHandler<ContextType,
+            DefaultOperationDelegateType.RequestType,
+            DefaultOperationDelegateType.ResponseHandlerType>, Shape)
     
     /**
      Adds a handler for the specified uri and http method.
-     
+ 
      - Parameters:
-     - uri: The uri to add the handler for.
-     - httpMethod: the http method to add the handler for.
-     - handler: the handler to add.
+        - uri: The uri to add the handler for.
+        - httpMethod: the http method to add the handler for.
+        - handler: the handler to add.
      */
     mutating func addHandlerForUri(_ uri: String,
                                    httpMethod: HTTPMethod,
                                    handler: OperationHandler<ContextType,
-        DefaultOperationDelegateType.RequestType,
-        DefaultOperationDelegateType.ResponseHandlerType>)
+                                    DefaultOperationDelegateType.RequestType,
+                                    DefaultOperationDelegateType.ResponseHandlerType>)
 }

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
@@ -14,7 +14,6 @@
 // SmokeOperationsSyncTests.swift
 // SmokeOperationsTests
 //
-
 import XCTest
 @testable import SmokeOperationsHTTP1
 import SmokeOperations
@@ -25,7 +24,16 @@ func handleExampleOperationVoid(input: ExampleInput, context: ExampleContext) th
     // This function intentionally left blank.
 }
 
+func handleExampleHTTP1OperationVoid(input: ExampleHTTP1Input, context: ExampleContext) throws {
+    input.validateForTest()
+}
+
 func handleBadOperationVoid(input: ExampleInput, context: ExampleContext) throws {
+    throw MyError.theError(reason: "Is bad!")
+}
+
+func handleBadHTTP1OperationVoid(input: ExampleHTTP1Input, context: ExampleContext) throws {
+    input.validateForTest()
     throw MyError.theError(reason: "Is bad!")
 }
 
@@ -34,142 +42,262 @@ func handleExampleOperation(input: ExampleInput, context: ExampleContext) throws
                             isGreat: true)
 }
 
+func handleExampleHTTP1Operation(input: ExampleHTTP1Input, context: ExampleContext) throws -> OutputHTTP1Attributes {
+    input.validateForTest()
+    return OutputHTTP1Attributes(bodyColor: input.theID == "123456789012" ? .blue : .yellow,
+                                 isGreat: true,
+                                 theHeader: input.theHeader)
+}
+
 func handleBadOperation(input: ExampleInput, context: ExampleContext) throws -> OutputAttributes {
+    throw MyError.theError(reason: "Is bad!")
+}
+
+func handleBadHTTP1Operation(input: ExampleHTTP1Input, context: ExampleContext) throws -> OutputHTTP1Attributes {
+    input.validateForTest()
     throw MyError.theError(reason: "Is bad!")
 }
 
 fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate> = {
     var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate>(
         defaultOperationDelegate: JSONPayloadHTTP1OperationDelegate())
-    newHandlerSelector.addHandlerForUri("exampleoperation", httpMethod: .POST,
-                                        operation: handleExampleOperation,
-                                        allowedErrors: allowedErrors)
+    newHandlerSelector.addHandlerForUri(
+        "exampleoperation", httpMethod: .POST,
+        operation: handleExampleOperation,
+        allowedErrors: allowedErrors,
+        inputLocation: .body,
+        outputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri("examplegetoperation", httpMethod: .GET,
-                                        operation: handleExampleOperation,
-                                        allowedErrors: allowedErrors)
+    newHandlerSelector.addHandlerForUri(
+        "exampleoperation/{theToken}", httpMethod: .POST,
+        operation: handleExampleHTTP1Operation,
+        allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri("examplenobodyoperation", httpMethod: .POST,
-                                        operation: handleExampleOperationVoid,
-                                        allowedErrors: allowedErrors)
+    newHandlerSelector.addHandlerForUri(
+        "examplegetoperation", httpMethod: .GET,
+        operation: handleExampleOperation,
+        allowedErrors: allowedErrors,
+        inputLocation: .body,
+        outputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri("badoperation", httpMethod: .POST,
-                                        operation: handleBadOperation,
-                                        allowedErrors: allowedErrors)
+    newHandlerSelector.addHandlerForUri(
+        "examplegetoperation/{theToken}", httpMethod: .GET,
+        operation: handleExampleHTTP1Operation,
+        allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri("badoperationvoidresponse", httpMethod: .POST,
-                                        operation: handleBadOperationVoid,
-                                        allowedErrors: allowedErrors)
+    newHandlerSelector.addHandlerForUri(
+        "examplenobodyoperation", httpMethod: .POST,
+        operation: handleExampleOperationVoid,
+        allowedErrors: allowedErrors,
+        inputLocation: .body)
+    
+    newHandlerSelector.addHandlerForUri(
+        "examplenobodyoperation/{theToken}", httpMethod: .POST,
+        operation: handleExampleHTTP1OperationVoid,
+        allowedErrors: allowedErrors)
+    
+    newHandlerSelector.addHandlerForUri(
+        "badoperation", httpMethod: .POST,
+        operation: handleBadOperation,
+        allowedErrors: allowedErrors,
+        inputLocation: .body,
+        outputLocation: .body)
+    
+    newHandlerSelector.addHandlerForUri(
+        "badoperation/{theToken}", httpMethod: .POST,
+        operation: handleBadHTTP1Operation,
+        allowedErrors: allowedErrors)
+    
+    newHandlerSelector.addHandlerForUri(
+        "badoperationvoidresponse", httpMethod: .POST,
+        operation: handleBadOperationVoid,
+        allowedErrors: allowedErrors,
+        inputLocation: .body)
+    
+    newHandlerSelector.addHandlerForUri(
+        "badoperationvoidresponse/{theToken}", httpMethod: .POST,
+        operation: handleBadHTTP1OperationVoid,
+        allowedErrors: allowedErrors)
     
     return newHandlerSelector
 }()
 
-private func verifyPathOutput(uri: String, body: Data) -> OperationResponse {
-    let handler = OperationServerHTTP1RequestHandler(handlerSelector: handlerSelector,
-                                                     context: ExampleContext())
-    
-    let httpRequestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
-                                          method: .POST,
-                                          uri: uri)
-    
-    let responseHandler = TestHttpResponseHandler()
-    
-    handler.handle(requestHead: httpRequestHead, body: body,
-                   responseHandler: responseHandler)
-    
-    return responseHandler.response!
-}
-
-private func verifyErrorResponse(uri: String) {
-    let response = verifyPathOutput(uri: uri,
-                                    body: serializedAlternateInput.data(using: .utf8)!)
-
-
-    XCTAssertEqual(response.status.code, 400)
-    let body = response.responseComponents.body!
-    let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
-                                                          from: body.data)
-
-    XCTAssertEqual("TheError", output.type)
-}
-
 class SmokeOperationsHTTP1SyncTests: XCTestCase {
     
-    func testExampleHandler() {
+    func testExampleHandler() throws {
         let response = verifyPathOutput(uri: "exampleOperation",
-                                        body: serializedInput.data(using: .utf8)!)
+                                        body: serializedInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector)
 
         
         XCTAssertEqual(response.status.code, 200)
         let body = response.responseComponents.body!
-        let output = try! JSONDecoder.getFrameworkDecoder().decode(OutputAttributes.self,
+        let output = try JSONDecoder.getFrameworkDecoder().decode(OutputAttributes.self,
                                                               from: body.data)
         let expectedOutput = OutputAttributes(bodyColor: .blue, isGreat: true)
+        XCTAssertEqual(expectedOutput, output)
+    }
+    
+    func testExampleHandlerWithTokenHeaderQuery() throws {
+        let response = verifyPathOutput(uri: "exampleoperation/suchToken?theParameter=muchParameter",
+                                        body: serializedInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector,
+                                        additionalHeaders: [("theHeader", "headerValue")])
+
+        
+        XCTAssertEqual(response.status.code, 200)
+        let body = response.responseComponents.body!
+        let output = try JSONDecoder.getFrameworkDecoder().decode(OutputBodyAttributes.self,
+                                                              from: body.data)
+        let expectedOutput = OutputBodyAttributes(bodyColor: .blue, isGreat: true)
         XCTAssertEqual(expectedOutput, output)
     }
 
     func testExampleVoidHandler() {
         let response = verifyPathOutput(uri: "exampleNoBodyOperation",
-                                        body: serializedInput.data(using: .utf8)!)
+                                        body: serializedInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector)
 
-        
-        XCTAssertEqual(response.status.code, 200)
         let body = response.responseComponents.body
+        XCTAssertEqual(response.status.code, 200)
+        XCTAssertNil(body)
+    }
+    
+    func testExampleVoidHandlerWithTokenHeaderQuery() {
+        let response = verifyPathOutput(uri: "exampleNoBodyOperation/suchToken?theParameter=muchParameter",
+                                        body: serializedInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector,
+                                        additionalHeaders: [("theHeader", "headerValue")])
+
+        let body = response.responseComponents.body
+        XCTAssertEqual(response.status.code, 200)
         XCTAssertNil(body)
     }
   
-    func testInputValidationError() {
+    func testInputValidationError() throws {
         let response = verifyPathOutput(uri: "exampleOperation",
-                                        body: serializedInvalidInput.data(using: .utf8)!)
+                                        body: serializedInvalidInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector)
 
         
         XCTAssertEqual(response.status.code, 400)
         let body = response.responseComponents.body!
-        let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
+        let output = try JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
                                                               from: body.data)
         
         XCTAssertEqual("ValidationError", output.type)
     }
+    
+    func testInputValidationErrorWithTokenHeaderQuery() throws {
+        let response = verifyPathOutput(uri: "exampleOperation/suchToken?theParameter=muchParameter",
+                                        body: serializedInvalidInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector,
+                                        additionalHeaders: [("theHeader", "headerValue")])
+        
+        
+        XCTAssertEqual(response.status.code, 400)
+        let body = response.responseComponents.body!
+        let output = try JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
+                                                                   from: body.data)
+        
+        XCTAssertEqual("ValidationError", output.type)
+    }
    
-    func testOutputValidationError() {
+    func testOutputValidationError() throws {
         let response = verifyPathOutput(uri: "exampleOperation",
-                                        body: serializedAlternateInput.data(using: .utf8)!)
+                                        body: serializedAlternateInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector)
 
         
         XCTAssertEqual(response.status.code, 500)
         let body = response.responseComponents.body!
-        let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
+        let output = try JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
                                                               from: body.data)
         
         XCTAssertEqual("InternalError", output.type)
     }
     
-    func testThrownError() {
-        verifyErrorResponse(uri: "badOperationVoidResponse")
-        verifyErrorResponse(uri: "badOperation")
+    func testOutputValidationErrorWithTokenHeaderQuery() throws {
+        let response = verifyPathOutput(uri: "exampleOperation/suchToken?theParameter=muchParameter",
+                                        body: serializedAlternateInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector,
+                                        additionalHeaders: [("theHeader", "headerValue")])
+        
+        
+        XCTAssertEqual(response.status.code, 500)
+        let body = response.responseComponents.body!
+        let output = try JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
+                                                                  from: body.data)
+        
+        XCTAssertEqual("InternalError", output.type)
     }
     
-    func testInvalidOperation() {
+    func testThrownErrorWithTokenHeaderQuery() throws {
+        try verifyErrorResponse(uri: "badOperationVoidResponse/suchToken?theParameter=muchParameter",
+                                handlerSelector: handlerSelector,
+                                additionalHeaders: [("theHeader", "headerValue")])
+        try verifyErrorResponse(uri: "badOperation/suchToken?theParameter=muchParameter",
+                                handlerSelector: handlerSelector,
+                                additionalHeaders: [("theHeader", "headerValue")])
+    }
+    
+    func testThrownError() throws {
+        try verifyErrorResponse(uri: "badOperationVoidResponse", handlerSelector: handlerSelector)
+        try verifyErrorResponse(uri: "badOperation", handlerSelector: handlerSelector)
+    }
+    
+    func testInvalidOperation() throws {
         let response = verifyPathOutput(uri: "unknownOperation",
-                                        body: serializedAlternateInput.data(using: .utf8)!)
+                                        body: serializedAlternateInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector)
 
         
         XCTAssertEqual(response.status.code, 400)
         let body = response.responseComponents.body!
-        let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
+        let output = try JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
                                                               from: body.data)
         
         XCTAssertEqual("InvalidOperation", output.type)
     }
     
-    func testIncorrectHTTPMethodOperation() {
+    func testInvalidOperationWithTokenHeaderQuery() throws {
+        let response = verifyPathOutput(uri: "unknownOperation/suchToken?theParameter=muchParameter",
+                                        body: serializedAlternateInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector,
+                                        additionalHeaders: [("theHeader", "headerValue")])
+        
+        
+        XCTAssertEqual(response.status.code, 400)
+        let body = response.responseComponents.body!
+        let output = try JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
+                                                                  from: body.data)
+        
+        XCTAssertEqual("InvalidOperation", output.type)
+    }
+    
+    func testIncorrectHTTPMethodOperation() throws {
         let response = verifyPathOutput(uri: "examplegetoperation",
-                                        body: serializedAlternateInput.data(using: .utf8)!)
+                                        body: serializedAlternateInput.data(using: .utf8)!,
+                                        handlerSelector: handlerSelector)
 
         
         XCTAssertEqual(response.status.code, 400)
         let body = response.responseComponents.body!
-        let output = try! JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
+        let output = try JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
+                                                              from: body.data)
+        
+        XCTAssertEqual("InvalidOperation", output.type)
+    }
+    
+    func testIncorrectHTTPMethodOperationWithTokenHeaderQuery() throws {
+         let response = verifyPathOutput(uri: "examplegetoperation/suchToken?theParameter=muchParameter",
+                                         body: serializedInput.data(using: .utf8)!,
+                                         handlerSelector: handlerSelector,
+                                         additionalHeaders: [("theHeader", "headerValue")])
+        
+        XCTAssertEqual(response.status.code, 400)
+        let body = response.responseComponents.body!
+        let output = try JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
                                                               from: body.data)
         
         XCTAssertEqual("InvalidOperation", output.type)
@@ -177,12 +305,19 @@ class SmokeOperationsHTTP1SyncTests: XCTestCase {
 
     static var allTests = [
         ("testExampleHandler", testExampleHandler),
+        ("testExampleHandlerWithTokenHeaderQuery", testExampleHandlerWithTokenHeaderQuery),
         ("testExampleVoidHandler", testExampleVoidHandler),
+        ("testExampleVoidHandlerWithTokenHeaderQuery", testExampleVoidHandlerWithTokenHeaderQuery),
         ("testInputValidationError", testInputValidationError),
+        ("testInputValidationErrorWithTokenHeaderQuery", testInputValidationErrorWithTokenHeaderQuery),
         ("testOutputValidationError", testOutputValidationError),
+        ("testOutputValidationErrorWithTokenHeaderQuery", testOutputValidationErrorWithTokenHeaderQuery),
         ("testThrownError", testThrownError),
+        ("testThrownErrorWithTokenHeaderQuery", testThrownErrorWithTokenHeaderQuery),
         ("testInvalidOperation", testInvalidOperation),
+        ("testInvalidOperationWithTokenHeaderQuery", testInvalidOperationWithTokenHeaderQuery),
         ("testIncorrectHTTPMethodOperation", testIncorrectHTTPMethodOperation),
+        ("testIncorrectHTTPMethodOperationWithTokenHeaderQuery",
+         testIncorrectHTTPMethodOperationWithTokenHeaderQuery)
     ]
 }
-

--- a/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
@@ -14,11 +14,12 @@
 // TestConfiguration.swift
 // SmokeOperationsTests
 //
-
 import Foundation
-@testable import SmokeOperations
+import SmokeOperations
 import NIOHTTP1
 import SmokeHTTP1
+@testable import SmokeOperationsHTTP1
+import XCTest
 
 struct ExampleContext {
 }
@@ -52,7 +53,7 @@ class TestHttpResponseHandler: HTTP1ResponseHandler {
     func complete(status: HTTPResponseStatus,
                   responseComponents: HTTP1ServerResponseComponents) {
         response = OperationResponse(status: status,
-                                    responseComponents: responseComponents)
+                                     responseComponents: responseComponents)
     }
 }
 
@@ -93,7 +94,7 @@ struct ErrorResponse: Codable {
     }
 }
 
-struct ExampleInput: Codable, Validatable {
+struct ExampleInput: Codable, Validatable, Equatable {
     let theID: String
     
     func validate() throws {
@@ -103,9 +104,56 @@ struct ExampleInput: Codable, Validatable {
     }
 }
 
-extension ExampleInput : Equatable {
-    static func ==(lhs: ExampleInput, rhs: ExampleInput) -> Bool {
-        return lhs.theID == rhs.theID
+struct ExampleQueryInput: Codable {
+    let theParameter: String
+}
+
+struct ExamplePathInput: Codable {
+    let theToken: String
+}
+
+struct ExampleBodyInput: Codable {
+    let theID: String
+}
+
+struct ExampleHeaderInput: Codable {
+    let theHeader: String
+}
+
+struct ExampleHTTP1Input: OperationHTTP1InputProtocol, Validatable, Equatable {
+    typealias QueryType = ExampleQueryInput
+    typealias PathType = ExamplePathInput
+    typealias BodyType = ExampleBodyInput
+    typealias HeadersType = ExampleHeaderInput
+    
+    let theID: String
+    let theToken: String
+    let theParameter: String
+    let theHeader: String
+    
+    func validate() throws {
+        if theID.count != 12 {
+            throw SmokeOperationsError.validationError(reason: "ID not the correct length.")
+        }
+    }
+    
+    static func compose(
+            queryDecodableProvider: () throws -> ExampleQueryInput,
+            pathDecodableProvider: () throws -> ExamplePathInput,
+            bodyDecodableProvider: () throws -> ExampleBodyInput,
+            headersDecodableProvider: () throws -> ExampleHeaderInput) throws -> ExampleHTTP1Input {
+        return ExampleHTTP1Input(theID: try bodyDecodableProvider().theID,
+                                 theToken: try pathDecodableProvider().theToken,
+                                 theParameter: try queryDecodableProvider().theParameter,
+                                 theHeader: try headersDecodableProvider().theHeader)
+    }
+}
+
+extension ExampleHTTP1Input {
+    func validateForTest() {
+        XCTAssertEqual("headerValue", theHeader)
+        XCTAssertEqual("muchParameter", theParameter)
+        XCTAssertEqual("suchToken", theToken)
     }
 }
 
@@ -114,7 +162,7 @@ enum BodyColor: String, Codable {
     case blue = "BLUE"
 }
 
-struct OutputAttributes: Codable, Validatable {
+struct OutputAttributes: Codable, Validatable, Equatable {
     let bodyColor: BodyColor
     let isGreat: Bool
     
@@ -125,9 +173,79 @@ struct OutputAttributes: Codable, Validatable {
     }
 }
 
-extension OutputAttributes : Equatable {
-    static func ==(lhs: OutputAttributes, rhs: OutputAttributes) -> Bool {
-        return lhs.bodyColor == rhs.bodyColor
-            && lhs.isGreat == rhs.isGreat
+struct OutputBodyAttributes: Codable, Equatable {
+    let bodyColor: BodyColor
+    let isGreat: Bool
+}
+
+struct OutputHeaderAttributes: Codable {
+    let theHeader: String
+}
+
+struct OutputHTTP1Attributes: OperationHTTP1OutputProtocol, Validatable, Equatable {
+    typealias BodyType = OutputBodyAttributes
+    typealias AdditionalHeadersType = OutputHeaderAttributes
+    
+    let bodyColor: BodyColor
+    let isGreat: Bool
+    let theHeader: String
+    
+    var bodyEncodable: OutputBodyAttributes? {
+        return OutputBodyAttributes(bodyColor: bodyColor, isGreat: isGreat)
     }
+    
+    var additionalHeadersEncodable: OutputHeaderAttributes? {
+        return OutputHeaderAttributes(theHeader: theHeader)
+    }
+    
+    func validate() throws {
+        if case .yellow = bodyColor {
+            throw SmokeOperationsError.validationError(reason: "The body color is yellow.")
+        }
+    }
+}
+
+func verifyPathOutput<SelectorType>(uri: String, body: Data,
+                                    handlerSelector: SelectorType,
+                                    additionalHeaders: [(String, String)] = []) -> OperationResponse
+where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ExampleContext,
+    SmokeHTTP1Request == SelectorType.DefaultOperationDelegateType.RequestType,
+    HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType {
+    let handler = OperationServerHTTP1RequestHandler<ExampleContext, SelectorType>(
+        handlerSelector: handlerSelector,
+        context: ExampleContext())
+    
+    var httpRequestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
+                                          method: .POST,
+                                          uri: uri)
+    additionalHeaders.forEach { header in
+        httpRequestHead.headers.add(name: header.0, value: header.1)
+    }
+    
+    let responseHandler = TestHttpResponseHandler()
+    
+    handler.handle(requestHead: httpRequestHead, body: body,
+                   responseHandler: responseHandler)
+    
+    return responseHandler.response!
+}
+
+func verifyErrorResponse<SelectorType>(uri: String,
+                                       handlerSelector: SelectorType,
+                                       additionalHeaders: [(String, String)] = []) throws
+where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ExampleContext,
+    SmokeHTTP1Request == SelectorType.DefaultOperationDelegateType.RequestType,
+    HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType {
+    let response = verifyPathOutput(uri: uri,
+                                    body: serializedAlternateInput.data(using: .utf8)!,
+                                    handlerSelector: handlerSelector,
+                                    additionalHeaders: additionalHeaders)
+    
+    
+    XCTAssertEqual(response.status.code, 400)
+    let body = response.responseComponents.body!
+    let output = try JSONDecoder.getFrameworkDecoder().decode(ErrorResponse.self,
+                                                              from: body.data)
+    
+    XCTAssertEqual("TheError", output.type)
 }


### PR DESCRIPTION
Add Operation1HTTPInputProtocol and Operation1HTTPOutputProtocol to support operation inputs and outputs composed of different parts of a HTTP1 request and response.

*Issue #, if available:* #5 

*Description of changes:*
* Add `Operation1HTTPInputProtocol` and `Operation1HTTPOutputProtocol` protocols with overloads of `SmokeHTTP1HandlerSelector.addHandlerForUri` to accept these protocols as input and output for operations. These are HTTP1-specific inputs and output that specifies how these types are composed from HTTP1 requests and responses (query, path, headers and body).
* Enhance `StandardSmokeHTTP1HandlerSelector` to be able to select handlers based on tokenized paths.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
