### PR TITLE
Improved shutdown behaviour

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "0dbd54199d06c80a35b441c39ac2ef1b78778740",
+          "version": "0.1.3"
+        }
+      },
+      {
         "package": "swift-nio-ssl",
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -31,12 +31,13 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "0.1.3"),
         .package(url: "https://github.com/amzn/smoke-http.git", from: "0.6.2"),
     ],
     targets: [
         .target(
             name: "SmokeHTTP1",
-            dependencies: ["NIO", "NIOHTTP1", "LoggerAPI"]),
+            dependencies: ["NIO", "NIOHTTP1", "NIOExtras", "LoggerAPI"]),
         .target(
             name: "SmokeOperations",
             dependencies: ["LoggerAPI"]),

--- a/README.md
+++ b/README.md
@@ -121,18 +121,26 @@ import LoggerAPI
 
 // Enable logging here
 
-let operationContext = ... 
+let operationsContext = ... 
 
 do {
-    try SmokeHTTP1Server.startAsOperationServer(
+    let smokeHTTP1Server = try SmokeHTTP1Server.startAsOperationServer(
         withHandlerSelector: createHandlerSelector(),
-        andContext: operationContext)
+        andContext: operationsContext)
+        
+    try smokeHTTP1Server.waitUntilShutdownAndThen {
+        // TODO: Close/shutdown any clients or credentials that are part
+        //       of the operationsContext.
+    }
 } catch {
     Log.error("Unable to start Operation Server: '\(error)'")
 }
 ```
 
-You can now run the application and the server will start up on port 8080. The application will block in the `startAsOperationServer` call.
+You can now run the application and the server will start up on port 8080. The application will block in the
+`smokeHTTP1Server.waitUntilShutdownAndThen` call. When the server has been fully shutdown and has
+completed all requests, the closure provided to this call will be executed. In this closure you can close/shutdown
+any clients or credentials that were created on startup for the operations context.
 
 # Further Concepts
 

--- a/Sources/SmokeHTTP1/GlobalDispatchQueueAsyncInvocationStrategy.swift
+++ b/Sources/SmokeHTTP1/GlobalDispatchQueueAsyncInvocationStrategy.swift
@@ -1,0 +1,36 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  GlobalDispatchQueueAsyncInvocationStrategy.swift
+//  SmokeHTTP1
+//
+
+import Foundation
+
+/**
+ An InvocationStrategy that will invocate the handler on
+ DispatchQueue.global(), not waiting for it to complete.
+ */
+public struct GlobalDispatchQueueAsyncInvocationStrategy: InvocationStrategy {
+    let queue = DispatchQueue.global()
+    
+    public init() {
+        
+    }
+    
+    public func invoke(handler: @escaping () -> ()) {
+        queue.async {
+            handler()
+        }
+    }
+}

--- a/Sources/SmokeHTTP1/GlobalDispatchQueueSyncInvocationStrategy.swift
+++ b/Sources/SmokeHTTP1/GlobalDispatchQueueSyncInvocationStrategy.swift
@@ -18,10 +18,10 @@
 import Foundation
 
 /**
- An AsyncInvocationStrategy that will invocate the handler on
- DispatchQueue.global().
+ An InvocationStrategy that will invocate the handler on
+ DispatchQueue.global(), waiting for it to complete.
  */
-public struct GlobalDispatchQueueInvocationStrategy: InvocationStrategy {
+public struct GlobalDispatchQueueSyncInvocationStrategy: InvocationStrategy {
     let queue = DispatchQueue.global()
     
     public init() {
@@ -29,7 +29,7 @@ public struct GlobalDispatchQueueInvocationStrategy: InvocationStrategy {
     }
     
     public func invoke(handler: @escaping () -> ()) {
-        queue.async {
+        queue.sync {
             handler()
         }
     }

--- a/Sources/SmokeHTTP1/SmokeHTTP1Server.swift
+++ b/Sources/SmokeHTTP1/SmokeHTTP1Server.swift
@@ -123,10 +123,10 @@ public class SmokeHTTP1Server {
     }
     
     /**
-     Starts the process of shutting down the server.
+     Initiates the process of shutting down the server.
      */
     public func shutdown() throws {
-        quiesce.initiateShutdown(promise: nil)
+        quiesce.initiateShutdown(promise: fullyShutdownPromise)
     }
     
     /**

--- a/Sources/SmokeHTTP1/SmokeHTTP1Server.swift
+++ b/Sources/SmokeHTTP1/SmokeHTTP1Server.swift
@@ -47,8 +47,10 @@ public class SmokeHTTP1Server {
     - Parameters:
         - handler: the HTTPRequestHandler to handle incoming requests.
         - port: Optionally the localhost port for the server to listen on.
+                If not specified, defaults to 8080.
         - invocationStrategy: Optionally the invocation strategy for incoming requests.
-                              If not specified, the handler for incoming requests will be invoked on DispatchQueue.global().
+                              If not specified, the handler for incoming requests will
+                              be invoked on DispatchQueue.global().
      */
     public init(handler: HTTP1RequestHandler,
                 port: Int = ServerDefaults.defaultPort,
@@ -80,6 +82,8 @@ public class SmokeHTTP1Server {
      either shutdown() is called or the surrounding application is being terminated.
      */
     public func start() throws {
+        Log.info("SmokeHTTP1Server starting on port \(port).")
+        
         let currentHandler = handler
         let currentInvocationStrategy = invocationStrategy
         
@@ -111,7 +115,11 @@ public class SmokeHTTP1Server {
             } catch {
                 Log.error("Server unable to shutdown cleanly following full shutdown.")
             }
+            
+            Log.info("SmokeHTTP1Server shutdown.")
         }
+        
+        Log.info("SmokeHTTP1Server started on port \(port).")
     }
     
     /**
@@ -129,11 +137,27 @@ public class SmokeHTTP1Server {
     }
     
     /**
-     Blocks until the server has been shut down.
+     Blocks until the server has been shut down. After the server
+     has been fully shutdown, the provided closure will be executed.
+     
+     - Parameters:
+        - onShutdown: the closure to be executed after the server has been
+                      fully shutdown.
      */
     public func waitUntilShutdownAndThen(onShutdown: @escaping () -> Void) throws {
         fullyShutdownPromise.futureResult.whenComplete(onShutdown)
         
         try fullyShutdownPromise.futureResult.wait()
+    }
+    
+    /**
+     Provides a closure to be executed after the server has been fully shutdown.
+     
+     - Parameters:
+        - onShutdown: the closure to be executed after the server has been
+                      fully shutdown.
+     */
+    public func onShutdown(onShutdown: @escaping () -> Void) throws {
+        fullyShutdownPromise.futureResult.whenComplete(onShutdown)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -34,7 +34,7 @@ public extension SmokeHTTP1Server {
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
         andPort port: Int = ServerDefaults.defaultPort,
-        invocationStrategy: InvocationStrategy = GlobalDispatchQueueInvocationStrategy()) throws
+        invocationStrategy: InvocationStrategy = GlobalDispatchQueueInvocationStrategy()) throws -> SmokeHTTP1Server
         where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
         SelectorType.DefaultOperationDelegateType.RequestType == SmokeHTTP1Request,
         SelectorType.DefaultOperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler {
@@ -51,6 +51,6 @@ public extension SmokeHTTP1Server {
             
             Log.info("Server started on port \(port)...")
             
-            RunLoop.current.run()
+            return server
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -41,7 +41,7 @@ public extension SmokeHTTP1Server {
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
         andPort port: Int = ServerDefaults.defaultPort,
-        invocationStrategy: InvocationStrategy = GlobalDispatchQueueInvocationStrategy()) throws -> SmokeHTTP1Server
+        invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy()) throws -> SmokeHTTP1Server
         where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
         SelectorType.DefaultOperationDelegateType.RequestType == SmokeHTTP1Request,
         SelectorType.DefaultOperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler {

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -23,12 +23,19 @@ import SmokeOperations
 public extension SmokeHTTP1Server {
     
     /**
-     Start the Http Server to handle operations.
+     Creates and starts a SmokeHTTP1Server to handle operations using the
+     provided handlerSelector.
      
      - Parameters:
-     - handlerSelector: the selector that will provide an operation
-     handler for a operation request
-     - context: the context to pass to operation handlers.
+         - handlerSelector: the selector that will provide an operation
+                            handler for a operation request
+         - context: the context to pass to operation handlers.
+         - port: Optionally the localhost port for the server to listen on.
+                 If not specified, defaults to 8080.
+         - invocationStrategy: Optionally the invocation strategy for incoming requests.
+                               If not specified, the handler for incoming requests will
+                               be invoked on DispatchQueue.global().
+     - Returns: the SmokeHTTP1Server that was created and started.
      */
     public static func startAsOperationServer<ContextType, SelectorType>(
         withHandlerSelector handlerSelector: SelectorType,
@@ -45,11 +52,7 @@ public extension SmokeHTTP1Server {
                                           port: port,
                                           invocationStrategy: invocationStrategy)
             
-            Log.info("Server starting on port \(port)...")
-            
             try server.start()
-            
-            Log.info("Server started on port \(port)...")
             
             return server
     }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -24,7 +24,7 @@ public extension SmokeHTTP1Server {
     
     /**
      Creates and starts a SmokeHTTP1Server to handle operations using the
-     provided handlerSelector.
+     provided handlerSelector. This call will return once the server has started.
      
      - Parameters:
          - handlerSelector: the selector that will provide an operation


### PR DESCRIPTION
*Issue #, if available:* #17 

*Description of changes:* Use the ServerQuiescingHelper from swift-nio-extras to handle shutdown. 
* Provide the ability to schedule actions to be completed (such as closing clients etc) after the server has been fully closed down and is no longer serving traffic.
* Improved some comments.
* Moved logging about server start into `SmokeHTTP1Server.start()` rather than `SmokeHTTP1Server.startAsOperationsServer()` as the former could be used separately and should get logging.
* Removed a `ThreadPool` from `SmokeHTTP1Server` that was just hanging out not doing anything.
* Changed `SmokeHTTP1Server.startAsOperationsServer()` to not block until the server shutdowns and to return the created and started server.
* Updated README with updated usage information.

*Testing performed:* Verified on a service in a beta environment that the service starts up, continues to function and can be shutdown.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
