### PR TITLE
Cleanup request handling with NIOFoundationCompat.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "fdb9c0574e3fc404763b744e808100622f3a9ded",
-          "version": "0.7.0"
+          "revision": "c41a262b43baf9f93b79bdffbeb3b41435f8a14e",
+          "version": "0.8.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "98434c1f1d687ff5a24d2cabfbd19b5c7d2d7a2f",
-          "version": "1.13.0"
+          "revision": "29a9f2aca71c8afb07e291336f1789337ce235dd",
+          "version": "1.13.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
     targets: [
         .target(
             name: "SmokeHTTP1",
-            dependencies: ["NIO", "NIOHTTP1", "NIOExtras", "LoggerAPI"]),
+            dependencies: ["NIO", "NIOHTTP1", "NIOFoundationCompat", "NIOExtras", "SmokeOperations", "LoggerAPI"]),
         .target(
             name: "SmokeOperations",
             dependencies: ["LoggerAPI"]),

--- a/Sources/SmokeOperations/GlobalDispatchQueueAsyncInvocationStrategy.swift
+++ b/Sources/SmokeOperations/GlobalDispatchQueueAsyncInvocationStrategy.swift
@@ -11,22 +11,26 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  AsyncInvocationStrategy.swift
-//  SmokeHTTP1
+//  GlobalDispatchQueueAsyncInvocationStrategy.swift
+//  SmokeOperations
 //
 
 import Foundation
 
 /**
- A strategy protocol that manages how to invocate a handler.
+ An InvocationStrategy that will invocate the handler on
+ DispatchQueue.global(), not waiting for it to complete.
  */
-public protocol InvocationStrategy {
+public struct GlobalDispatchQueueAsyncInvocationStrategy: InvocationStrategy {
+    let queue = DispatchQueue.global()
     
-    /**
-     Function to handle the invocation of the handler.
- 
-     - Parameters:
-        - handler: The handler to invocate.
-     */
-    func invoke(handler: @escaping () -> ())
+    public init() {
+        
+    }
+    
+    public func invoke(handler: @escaping () -> ()) {
+        queue.async {
+            handler()
+        }
+    }
 }

--- a/Sources/SmokeOperations/GlobalDispatchQueueSyncInvocationStrategy.swift
+++ b/Sources/SmokeOperations/GlobalDispatchQueueSyncInvocationStrategy.swift
@@ -12,7 +12,7 @@
 // permissions and limitations under the License.
 //
 //  GlobalDispatchQueueAsyncInvocationStrategy.swift
-//  SmokeHTTP1
+//  SmokeOperations
 //
 
 import Foundation

--- a/Sources/SmokeOperations/InvocationStrategy.swift
+++ b/Sources/SmokeOperations/InvocationStrategy.swift
@@ -11,26 +11,22 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  GlobalDispatchQueueAsyncInvocationStrategy.swift
-//  SmokeHTTP1
+//  InvocationStrategy.swift
+//  SmokeOperations
 //
 
 import Foundation
 
 /**
- An InvocationStrategy that will invocate the handler on
- DispatchQueue.global(), not waiting for it to complete.
+ A strategy protocol that manages how to invocate a handler.
  */
-public struct GlobalDispatchQueueAsyncInvocationStrategy: InvocationStrategy {
-    let queue = DispatchQueue.global()
+public protocol InvocationStrategy {
     
-    public init() {
-        
-    }
-    
-    public func invoke(handler: @escaping () -> ()) {
-        queue.async {
-            handler()
-        }
-    }
+    /**
+     Function to handle the invocation of the handler.
+ 
+     - Parameters:
+        - handler: The handler to invocate.
+     */
+    func invoke(handler: @escaping () -> ())
 }

--- a/Sources/SmokeOperations/JSONDecoder+getFrameworkDecoder.swift
+++ b/Sources/SmokeOperations/JSONDecoder+getFrameworkDecoder.swift
@@ -26,11 +26,9 @@ private func createDecoder() -> JSONDecoder {
     return jsonDecoder
 }
 
-private let jsonDecoder = createDecoder()
-
 extension JSONDecoder {
     /// Return a SmokeFramework compatible JSON Decoder
     public static func getFrameworkDecoder() -> JSONDecoder {
-        return jsonDecoder
+        return createDecoder()
     }
 }

--- a/Sources/SmokeOperations/JSONEncoder+getFrameworkEncoder.swift
+++ b/Sources/SmokeOperations/JSONEncoder+getFrameworkEncoder.swift
@@ -29,11 +29,9 @@ private func createEncoder() -> JSONEncoder {
     return jsonEncoder
 }
 
-private let jsonEncoder = createEncoder()
-
 // swiftlint:disable force_try
 // If all else fails, an error payload to use.
-private let encodedInternalError = try! jsonEncoder.encode(
+private let encodedInternalError = try! createEncoder().encode(
     ErrorWithType(type: "InternalError",
                   payload: SmokeOperationsErrorPayload(errorMessage: nil)))
 // swiftlint:enable force_try
@@ -41,7 +39,7 @@ private let encodedInternalError = try! jsonEncoder.encode(
 extension JSONEncoder {
     /// Return a SmokeFramework compatible JSON Encoder
     public static func getFrameworkEncoder() -> JSONEncoder {
-        return jsonEncoder
+        return createEncoder()
     }
     
     /**
@@ -60,9 +58,9 @@ extension JSONEncoder {
                 if let reason = reason {
                     let errorWithReason = ErrorWithType(type: reason,
                                                         payload: payload)
-                    encodedError = try jsonEncoder.encode(errorWithReason)
+                    encodedError = try createEncoder().encode(errorWithReason)
                 } else {
-                    encodedError = try jsonEncoder.encode(payload)
+                    encodedError = try createEncoder().encode(payload)
                 }
             } catch {
                 Log.error("Unable to encode error message: \(error)")

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -35,13 +35,17 @@ public extension SmokeHTTP1Server {
          - invocationStrategy: Optionally the invocation strategy for incoming requests.
                                If not specified, the handler for incoming requests will
                                be invoked on DispatchQueue.global().
+         - eventLoopProvider: Provides the event loop to be used by the server.
+                              If not specified, the server will create a new multi-threaded event loop
+                              with the number of threads specified by `System.coreCount`.
      - Returns: the SmokeHTTP1Server that was created and started.
      */
     public static func startAsOperationServer<ContextType, SelectorType>(
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
         andPort port: Int = ServerDefaults.defaultPort,
-        invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy()) throws -> SmokeHTTP1Server
+        invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),
+        eventLoopProvider: EventLoopProvider = .spawnNewThreads) throws -> SmokeHTTP1Server
         where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
         SelectorType.DefaultOperationDelegateType.RequestType == SmokeHTTP1Request,
         SelectorType.DefaultOperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler {
@@ -50,7 +54,8 @@ public extension SmokeHTTP1Server {
                 context: context)
             let server = SmokeHTTP1Server(handler: handler,
                                           port: port,
-                                          invocationStrategy: invocationStrategy)
+                                          invocationStrategy: invocationStrategy,
+                                          eventLoopProvider: eventLoopProvider)
             
             try server.start()
             


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* cleanup request handling with NIOFoundationCompat.
* add the ability to provide the event loop for the server
* move `InvocationStrategy` and its conforming types from `SmokeHTTP1` to `SmokeOperations` as they are not HTTP1 specific.
* don't use singleton JSONEncoder and JSONDecoder instances.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
