### PR TITLE
Optimise how SwiftNIO ByteBuffers are used

### DIFF
--- a/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
@@ -141,11 +141,10 @@ class HTTP1ChannelInboundHandler: ChannelInboundHandler {
         let currentHandler = handler
         
         // pass to the request handler to complete
-        invocationStrategy.invoke {
-            currentHandler.handle(requestHead: requestHead,
-                                  body: bodyData,
-                                  responseHandler: responseHandler)
-        }
+        currentHandler.handle(requestHead: requestHead,
+                              body: bodyData,
+                              responseHandler: responseHandler,
+                              invocationStrategy: invocationStrategy)
     }
     
     /**

--- a/Sources/SmokeHTTP1/HTTP1RequestHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1RequestHandler.swift
@@ -18,6 +18,7 @@
 import Foundation
 import NIO
 import NIOHTTP1
+import SmokeOperations
 
 /**
  Protocol that specifies a handler for a HttpRequest.
@@ -30,6 +31,8 @@ public protocol HTTP1RequestHandler {
         - requestHead: the parameters specified in the head of the HTTP request.
         - body: the body of the request, if any.
         - responseHandler: a handler that can be used to respond to the request.
+        - invocationStrategy: the invocationStrategy to use for this request.
      */
-    func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: HTTP1ResponseHandler)
+    func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: HTTP1ResponseHandler,
+                invocationStrategy: InvocationStrategy)
 }

--- a/Sources/SmokeHTTP1/HTTP1ResponseHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1ResponseHandler.swift
@@ -35,6 +35,15 @@ public protocol HTTP1ResponseHandler {
     func complete(status: HTTPResponseStatus, responseComponents: HTTP1ServerResponseComponents)
     
     /**
+     Function used to provide a response to a HTTP request on the server event loop.
+     
+     - Parameters:
+        - status: the status to provide in the response.
+        - responseComponents: the components to send in the response.
+     */
+    func completeInEventLoop(status: HTTPResponseStatus, responseComponents: HTTP1ServerResponseComponents)
+    
+    /**
      Function used to provide a response to a HTTP request. The response will not be
      reported at standard logging levels.
  
@@ -44,6 +53,25 @@ public protocol HTTP1ResponseHandler {
      */
     func completeSilently(status: HTTPResponseStatus,
                           responseComponents: HTTP1ServerResponseComponents)
+    
+    /**
+     Function used to provide a response to a HTTP request on the server event loop. The
+     response will not be reported at standard logging levels.
+     
+     - Parameters:
+        - status: the status to provide in the response.
+        - body: the content type and data to use for the response.
+     */
+    func completeSilentlyInEventLoop(status: HTTPResponseStatus,
+                                     responseComponents: HTTP1ServerResponseComponents)
+    
+    /**
+     Execute the provided closure in the event loop corresponding to the response.
+ 
+     - Parameters:
+        - execute: the closure to execute.
+     */
+    func executeInEventLoop(execute: @escaping () -> ())
 }
 
 public extension HTTP1ResponseHandler {

--- a/Sources/SmokeOperations/OperationDelegate.swift
+++ b/Sources/SmokeOperations/OperationDelegate.swift
@@ -22,8 +22,8 @@ import Foundation
  a transport protocol.
  */
 public protocol OperationDelegate {
-    /// The type of the request used with this delegate.
-    associatedtype RequestType
+    /// The type of the request head used with this delegate.
+    associatedtype RequestHeadType
     /// The type of response handler used with this delegate.
     associatedtype ResponseHandlerType
     
@@ -31,67 +31,67 @@ public protocol OperationDelegate {
      Function to handle a successful operation with no response.
  
      - Parameters:
-        - request: The original request corresponding to the operation. Can be used to determine how to
+        - requestHead: The original request head corresponding to the operation. Can be used to determine how to
           handle the response (such as requested response type).
         - responseHander: typically a response handler specific to the transport protocol being used.
      */
-    func handleResponseForOperationWithNoOutput(request: RequestType, responseHandler: ResponseHandlerType)
+    func handleResponseForOperationWithNoOutput(requestHead: RequestHeadType, responseHandler: ResponseHandlerType)
     
     /**
      Function to handle an operation failure.
  
      - Parameters:
-        - request: The original request corresponding to the operation. Can be used to determine how to
+        - requestHead: The original request head corresponding to the operation. Can be used to determine how to
           handle the response (such as requested response type).
         - operationFailure: The cause of the operation failure.
         - responseHander: typically a response handler specific to the transport protocol being used.
      */
-    func handleResponseForOperationFailure(request: RequestType, operationFailure: OperationFailure,
+    func handleResponseForOperationFailure(requestHead: RequestHeadType, operationFailure: OperationFailure,
                                            responseHandler: ResponseHandlerType)
     
     /**
      Function to handle an internal server error.
  
      - Parameters:
-        - request: The original request corresponding to the operation. Can be used to determine how to
+        - requestHead: The original request head corresponding to the operation. Can be used to determine how to
           handle the response (such as requested response type).
         - responseHander: typically a response handler specific to the transport protocol being used.
      */
-    func handleResponseForInternalServerError(request: RequestType, responseHandler: ResponseHandlerType)
+    func handleResponseForInternalServerError(requestHead: RequestHeadType, responseHandler: ResponseHandlerType)
     
     /**
      Function to handle an invalid operation being requested.
  
      - Parameters:
-        - request: The original request corresponding to the operation. Can be used to determine how to
+        - requestHead: The original request head corresponding to the operation. Can be used to determine how to
           handle the response (such as requested response type).
         - message: A message corressponding to the failure.
         - responseHander: typically a response handler specific to the transport protocol being used.
      */
-    func handleResponseForInvalidOperation(request: RequestType, message: String,
+    func handleResponseForInvalidOperation(requestHead: RequestHeadType, message: String,
                                            responseHandler: ResponseHandlerType)
     
     /**
      Function to handle a decoding error.
  
      - Parameters:
-        - request: The original request corresponding to the operation. Can be used to determine how to
+        - requestHead: The original request head corresponding to the operation. Can be used to determine how to
           handle the response (such as requested response type).
         - message: A message corressponding to the failure.
         - responseHander: typically a response handler specific to the transport protocol being used.
      */
-    func handleResponseForDecodingError(request: RequestType, message: String,
+    func handleResponseForDecodingError(requestHead: RequestHeadType, message: String,
                                         responseHandler: ResponseHandlerType)
     
     /**
      Function to handle a validation error.
  
      - Parameters:
-        - request: The original request corresponding to the operation. Can be used to determine how to
+        - requestHead: The original request head corresponding to the operation. Can be used to determine how to
           handle the response (such as requested response type).
         - message: A message corressponding to the failure.
         - responseHander: typically a response handler specific to the transport protocol being used.
      */
-    func handleResponseForValidationError(request: RequestType, message: String?,
+    func handleResponseForValidationError(requestHead: RequestHeadType, message: String?,
                                           responseHandler: ResponseHandlerType)
 }

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
@@ -32,11 +32,11 @@ public extension OperationHandler {
           handling the operation.
      */
     public init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
-            inputProvider: @escaping (OperationDelegateType.RequestType) throws -> InputType,
+            inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
-    where RequestType == OperationDelegateType.RequestType,
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -44,7 +44,7 @@ public extension OperationHandler {
          * returns, the responseHandler is called to indicate success. If the provided operation
          * throws an error, the responseHandler is called with that error.
          */
-        let wrappedInputHandler = { (input: InputType, request: RequestType, context: ContextType,
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
                                      responseHandler: ResponseHandlerType) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>
             do {
@@ -62,7 +62,7 @@ public extension OperationHandler {
             OperationHandler.handleNoOutputOperationHandlerResult(
                 handlerResult: handlerResult,
                 operationDelegate: operationDelegate,
-                request: request,
+                requestHead: requestHead,
                 responseHandler: responseHandler)
         }
         

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
@@ -34,12 +34,12 @@ public extension OperationHandler {
      */
     public init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: OperationDelegate>(
-            inputProvider: @escaping (RequestType) throws -> InputType,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping (InputType, ContextType) throws -> OutputType,
-            outputHandler: @escaping ((RequestType, OutputType, ResponseHandlerType) -> Void),
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType) -> Void),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
-    where RequestType == OperationDelegateType.RequestType,
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -47,7 +47,7 @@ public extension OperationHandler {
          * returns, the responseHandler is called with the result. If the provided operation
          * throws an error, the responseHandler is called with that error.
          */
-        let wrappedInputHandler = { (input: InputType, request: RequestType, context: ContextType,
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
                                      responseHandler: OperationDelegateType.ResponseHandlerType) in
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
             do {
@@ -65,7 +65,7 @@ public extension OperationHandler {
             OperationHandler.handleWithOutputOperationHandlerResult(
                 handlerResult: handlerResult,
                 operationDelegate: operationDelegate,
-                request: request,
+                requestHead: requestHead,
                 responseHandler: responseHandler,
                 outputHandler: outputHandler)
         }

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
@@ -32,11 +32,11 @@ public extension OperationHandler {
           handling the operation.
      */
     public init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
-            inputProvider: @escaping (RequestType) throws -> InputType,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
-    where RequestType == OperationDelegateType.RequestType,
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -44,7 +44,7 @@ public extension OperationHandler {
          * called to indicate success when the input handler's response handler is called. If the provided operation
          * provides an error, the responseHandler is called with that error.
          */
-        let wrappedInputHandler = { (input: InputType, request: RequestType, context: ContextType,
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
                                      responseHandler: ResponseHandlerType) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>?
             do {
@@ -67,7 +67,7 @@ public extension OperationHandler {
                     OperationHandler.handleNoOutputOperationHandlerResult(
                         handlerResult: asyncHandlerResult,
                         operationDelegate: operationDelegate,
-                        request: request,
+                        requestHead: requestHead,
                         responseHandler: responseHandler)
                 }
                 
@@ -86,7 +86,7 @@ public extension OperationHandler {
                 OperationHandler.handleNoOutputOperationHandlerResult(
                     handlerResult: handlerResult,
                     operationDelegate: operationDelegate,
-                    request: request,
+                    requestHead: requestHead,
                     responseHandler: responseHandler)
             }
         }

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
@@ -34,13 +34,13 @@ public extension OperationHandler {
      */
     public init<InputType: Validatable, OutputType: Validatable,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
-            inputProvider: @escaping (RequestType) throws -> InputType,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType, @escaping
                 (SmokeResult<OutputType>) -> Void) throws -> Void),
-            outputHandler: @escaping ((RequestType, OutputType, ResponseHandlerType) -> Void),
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType) -> Void),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
-    where RequestType == OperationDelegateType.RequestType,
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -48,7 +48,7 @@ public extension OperationHandler {
          * called with the result when the input handler's response handler is called. If the provided operation
          * provides an error, the responseHandler is called with that error.
          */
-        let wrappedInputHandler = { (input: InputType, request: RequestType, context: ContextType,
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
                                      responseHandler: ResponseHandlerType) in
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>?
             do {
@@ -72,7 +72,7 @@ public extension OperationHandler {
                     OperationHandler.handleWithOutputOperationHandlerResult(
                         handlerResult: asyncHandlerResult,
                         operationDelegate: operationDelegate,
-                        request: request,
+                        requestHead: requestHead,
                         responseHandler: responseHandler,
                         outputHandler: outputHandler)
                 }
@@ -92,7 +92,7 @@ public extension OperationHandler {
                 OperationHandler.handleWithOutputOperationHandlerResult(
                     handlerResult: handlerResult,
                     operationDelegate: operationDelegate,
-                    request: request,
+                    requestHead: requestHead,
                     responseHandler: responseHandler,
                     outputHandler: outputHandler)
             }

--- a/Sources/SmokeOperations/OperationHandlerExtensions.swift
+++ b/Sources/SmokeOperations/OperationHandlerExtensions.swift
@@ -84,38 +84,38 @@ public extension OperationHandler {
     public static func handleNoOutputOperationHandlerResult<ErrorType, OperationDelegateType: OperationDelegate>(
         handlerResult: NoOutputOperationHandlerResult<ErrorType>,
         operationDelegate: OperationDelegateType,
-        request: OperationDelegateType.RequestType,
+        requestHead: OperationDelegateType.RequestHeadType,
         responseHandler: OperationDelegateType.ResponseHandlerType)
-    where RequestType == OperationDelegateType.RequestType,
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             switch handlerResult {
             case .internalServerError(let error):
                 Log.error("Unexpected failure: \(error)")
                 operationDelegate.handleResponseForInternalServerError(
-                    request: request,
+                    requestHead: requestHead,
                     responseHandler: responseHandler)
             case .smokeReturnableError(let error, let allowedErrors):
                 if let operationFailure =
                     OperationHandler.fromSmokeReturnableError(error: error,
                                                               allowedErrors: allowedErrors) {
                         operationDelegate.handleResponseForOperationFailure(
-                            request: request,
+                            requestHead: requestHead,
                             operationFailure: operationFailure,
                             responseHandler: responseHandler)
                 } else {
                     Log.error("Unexpected error type returned: \(error)")
                     operationDelegate.handleResponseForInternalServerError(
-                        request: request,
+                        requestHead: requestHead,
                         responseHandler: responseHandler)
                 }
             case .success:
                 operationDelegate.handleResponseForOperationWithNoOutput(
-                    request: request,
+                    requestHead: requestHead,
                     responseHandler: responseHandler)
             case .validationError(let reason):
                 Log.info("ValidationError: \(reason)")
                 operationDelegate.handleResponseForValidationError(
-                    request: request,
+                    requestHead: requestHead,
                     message: reason,
                     responseHandler: responseHandler)
             }
@@ -135,47 +135,47 @@ public extension OperationHandler {
     public static func handleWithOutputOperationHandlerResult<OutputType, ErrorType, OperationDelegateType: OperationDelegate>(
         handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>,
         operationDelegate: OperationDelegateType,
-        request: RequestType,
+        requestHead: RequestHeadType,
         responseHandler: ResponseHandlerType,
-        outputHandler: @escaping ((RequestType, OutputType, ResponseHandlerType) -> Void))
-    where RequestType == OperationDelegateType.RequestType,
+        outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType) -> Void))
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             switch handlerResult {
             case .internalServerError(let error):
                 Log.error("Unexpected failure: \(error)")
                 operationDelegate.handleResponseForInternalServerError(
-                    request: request,
+                    requestHead: requestHead,
                     responseHandler: responseHandler)
             case .smokeReturnableError(let error, let allowedErrors):
                 if let operationFailure =
                     OperationHandler.fromSmokeReturnableError(error: error,
                                                               allowedErrors: allowedErrors) {
                         operationDelegate.handleResponseForOperationFailure(
-                            request: request,
+                            requestHead: requestHead,
                             operationFailure: operationFailure,
                             responseHandler: responseHandler)
                 } else {
                     Log.error("Unexpected error type returned: \(error)")
                     operationDelegate.handleResponseForInternalServerError(
-                        request: request,
+                        requestHead: requestHead,
                         responseHandler: responseHandler)
                 }
             case .success(let output):
                 do {
                     try output.validate()
                     
-                    outputHandler(request, output, responseHandler)
+                    outputHandler(requestHead, output, responseHandler)
                 } catch {
                     Log.error("Serialization error: unable to get response: \(error)")
                     
                     operationDelegate.handleResponseForInternalServerError(
-                        request: request,
+                        requestHead: requestHead,
                         responseHandler: responseHandler)
                 }
             case .validationError(let reason):
                 Log.info("ValidationError: \(reason)")
                 operationDelegate.handleResponseForValidationError(
-                    request: request,
+                    requestHead: requestHead,
                     message: reason,
                     responseHandler: responseHandler)
             }

--- a/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
+++ b/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
@@ -39,26 +39,27 @@ public protocol HTTP1OperationDelegate: OperationDelegate {
      Function to retrieve an instance of the InputType from the request. Will throw an error
      if an instance of InputType cannot be constructed from the request.
      */
-    func getInputForOperation<InputType: OperationHTTP1InputProtocol>(request: RequestType) throws -> InputType
+    func getInputForOperation<InputType: OperationHTTP1InputProtocol>(requestHead: RequestHeadType, body: Data?) throws -> InputType
     
     /**
      Function to retrieve an instance of the InputType from the request. Will throw an error
      if an instance of InputType cannot be constructed from the request.
      */
-    func getInputForOperation<InputType: Decodable>(request: RequestType,
+    func getInputForOperation<InputType: Decodable>(requestHead: RequestHeadType,
+                                                    body: Data?,
                                                     location: OperationInputHTTPLocation) throws -> InputType
     
     /**
      Function to handle a successful response from an operation.
  
      - Parameters:
-        - request: The original request corresponding to the operation. Can be used to determine how to
+        - requestHead: The original request head corresponding to the operation. Can be used to determine how to
           handle the response (such as requested response type).
         - output: The instance of the OutputType to send as a response.
         - responseHander: typically a response handler specific to the transport protocol being used.
      */
     func handleResponseForOperation<OutputType: OperationHTTP1OutputProtocol>(
-        request: RequestType,
+        requestHead: RequestHeadType,
         output: OutputType,
         responseHandler: ResponseHandlerType)
     
@@ -66,12 +67,12 @@ public protocol HTTP1OperationDelegate: OperationDelegate {
      Function to handle a successful response from an operation.
  
      - Parameters:
-        - request: The original request corresponding to the operation. Can be used to determine how to
+        - requestHead: The original request head corresponding to the operation. Can be used to determine how to
           handle the response (such as requested response type).
         - output: The instance of the OutputType to send as a response.
         - responseHander: typically a response handler specific to the transport protocol being used.
      */
-    func handleResponseForOperation<OutputType: Encodable>(request: RequestType,
+    func handleResponseForOperation<OutputType: Encodable>(requestHead: RequestHeadType,
                                                            location: OperationOutputHTTPLocation,
                                                            output: OutputType,
                                                            responseHandler: ResponseHandlerType)

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
@@ -39,9 +39,10 @@ public extension SmokeHTTP1HandlerSelector {
         
         // don't capture self
         let delegateToUse = defaultOperationDelegate
-        func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
             return try delegateToUse.getInputForOperation(
-                request: request,
+                requestHead: requestHead,
+                body: body,
                 location: inputLocation)
         }
         
@@ -73,12 +74,13 @@ public extension SmokeHTTP1HandlerSelector {
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation,
         operationDelegate: OperationDelegateType)
-        where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
-            func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
                 return try operationDelegate.getInputForOperation(
-                    request: request,
+                    requestHead: requestHead,
+                    body: body,
                     location: inputLocation)
             }
             
@@ -135,7 +137,7 @@ public extension SmokeHTTP1HandlerSelector {
         operation: @escaping ((InputType, ContextType) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
-    where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
@@ -41,16 +41,17 @@ public extension SmokeHTTP1HandlerSelector {
         
         // don't capture self
         let delegateToUse = defaultOperationDelegate
-        func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
             return try delegateToUse.getInputForOperation(
-                request: request,
+                requestHead: requestHead,
+                body: body,
                 location: inputLocation)
         }
         
-        func outputHandler(request: DefaultOperationDelegateType.RequestType,
+        func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
                            output: OutputType,
                            responseHandler: DefaultOperationDelegateType.ResponseHandlerType) {
-            delegateToUse.handleResponseForOperation(request: request,
+            delegateToUse.handleResponseForOperation(requestHead: requestHead,
                                                      location: outputLocation,
                                                      output: output,
                                                      responseHandler: responseHandler)
@@ -86,19 +87,20 @@ public extension SmokeHTTP1HandlerSelector {
         inputLocation: OperationInputHTTPLocation,
         outputLocation: OperationOutputHTTPLocation,
         operationDelegate: OperationDelegateType)
-        where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
-            func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
                 return try operationDelegate.getInputForOperation(
-                    request: request,
+                    requestHead: requestHead,
+                    body: body,
                     location: inputLocation)
             }
             
-            func outputHandler(request: OperationDelegateType.RequestType,
+            func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
                                output: OutputType,
                                responseHandler: OperationDelegateType.ResponseHandlerType) {
-                operationDelegate.handleResponseForOperation(request: request,
+                operationDelegate.handleResponseForOperation(requestHead: requestHead,
                                                              location: outputLocation,
                                                              output: output,
                                                              responseHandler: responseHandler)
@@ -160,7 +162,7 @@ public extension SmokeHTTP1HandlerSelector {
         operation: @escaping ((InputType, ContextType) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
-    where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
@@ -43,9 +43,10 @@ public extension SmokeHTTP1HandlerSelector {
         
         // don't capture self
         let delegateToUse = defaultOperationDelegate
-        func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
             return try delegateToUse.getInputForOperation(
-                request: request,
+                requestHead: requestHead,
+                body: body,
                 location: inputLocation)
         }
         
@@ -77,16 +78,17 @@ public extension SmokeHTTP1HandlerSelector {
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation,
         operationDelegate: OperationDelegateType)
-        where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func outputProvider(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {
                 try operation(input, context, completion)
             }
             
-            func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
                 return try operationDelegate.getInputForOperation(
-                    request: request,
+                    requestHead: requestHead,
+                    body: body,
                     location: inputLocation)
             }
             
@@ -147,7 +149,7 @@ public extension SmokeHTTP1HandlerSelector {
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
-    where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         func outputProvider(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
@@ -41,16 +41,17 @@ public extension SmokeHTTP1HandlerSelector {
         
         // don't capture self
         let delegateToUse = defaultOperationDelegate
-        func inputProvider(request: DefaultOperationDelegateType.RequestType) throws -> InputType {
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
             return try delegateToUse.getInputForOperation(
-                request: request,
+                requestHead: requestHead,
+                body: body,
                 location: inputLocation)
         }
         
-        func outputHandler(request: DefaultOperationDelegateType.RequestType,
+        func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
                            output: OutputType,
                            responseHandler: DefaultOperationDelegateType.ResponseHandlerType) {
-            delegateToUse.handleResponseForOperation(request: request,
+            delegateToUse.handleResponseForOperation(requestHead: requestHead,
                                                      location: outputLocation,
                                                      output: output,
                                                      responseHandler: responseHandler)
@@ -86,19 +87,20 @@ public extension SmokeHTTP1HandlerSelector {
         inputLocation: OperationInputHTTPLocation,
         outputLocation: OperationOutputHTTPLocation,
         operationDelegate: OperationDelegateType)
-        where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
-            func inputProvider(request: OperationDelegateType.RequestType) throws -> InputType {
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
                 return try operationDelegate.getInputForOperation(
-                    request: request,
+                    requestHead: requestHead,
+                    body: body,
                     location: inputLocation)
             }
             
-            func outputHandler(request: OperationDelegateType.RequestType,
+            func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
                                output: OutputType,
                                responseHandler: OperationDelegateType.ResponseHandlerType) {
-                operationDelegate.handleResponseForOperation(request: request,
+                operationDelegate.handleResponseForOperation(requestHead: requestHead,
                                                              location: outputLocation,
                                                              output: output,
                                                              responseHandler: responseHandler)
@@ -158,7 +160,7 @@ public extension SmokeHTTP1HandlerSelector {
         operation: @escaping ((InputType, ContextType, @escaping (SmokeResult<OutputType>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
-    where DefaultOperationDelegateType.RequestType == OperationDelegateType.RequestType,
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
@@ -39,7 +39,7 @@ public protocol SmokeHTTP1HandlerSelector {
      */
     func getHandlerForOperation(_ uri: String, httpMethod: HTTPMethod) throws
         -> (OperationHandler<ContextType,
-            DefaultOperationDelegateType.RequestType,
+            DefaultOperationDelegateType.RequestHeadType,
             DefaultOperationDelegateType.ResponseHandlerType>, Shape)
     
     /**
@@ -53,6 +53,6 @@ public protocol SmokeHTTP1HandlerSelector {
     mutating func addHandlerForUri(_ uri: String,
                                    httpMethod: HTTPMethod,
                                    handler: OperationHandler<ContextType,
-                                    DefaultOperationDelegateType.RequestType,
+                                    DefaultOperationDelegateType.RequestHeadType,
                                     DefaultOperationDelegateType.ResponseHandlerType>)
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1RequestHead.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1RequestHead.swift
@@ -21,11 +21,10 @@ import SmokeHTTP1
 import ShapeCoding
 
 /**
- Structure representing an incoming HTTP1 request.
+ Structure representing an incoming HTTP1 request head.
  */
-public struct SmokeHTTP1Request {
+public struct SmokeHTTP1RequestHead {
     public let httpRequestHead: HTTPRequestHead
     public let query: String
     public let pathShape: Shape
-    public let body: Data?
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -47,7 +47,7 @@ public extension SmokeHTTP1Server {
         invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),
         eventLoopProvider: EventLoopProvider = .spawnNewThreads) throws -> SmokeHTTP1Server
         where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
-        SelectorType.DefaultOperationDelegateType.RequestType == SmokeHTTP1Request,
+        SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
         SelectorType.DefaultOperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler {
             let handler = OperationServerHTTP1RequestHandler(
                 handlerSelector: handlerSelector,

--- a/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
@@ -30,7 +30,7 @@ public struct StandardSmokeHTTP1HandlerSelector<ContextType, DefaultOperationDel
     public let defaultOperationDelegate: DefaultOperationDelegateType
     
     public typealias SelectorOperationHandlerType = OperationHandler<ContextType,
-            DefaultOperationDelegateType.RequestType,
+            DefaultOperationDelegateType.RequestHeadType,
             DefaultOperationDelegateType.ResponseHandlerType>
     
     private struct TokenizedHandler {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Decode and encode requests and response in the event loop to avoid retaining Data instances during processing on DispatchQueue.global.
* Don't keep the request data body around for the duration of the request. `SmokeHTTP1Request` becomes `SmokeHTTP1RequestHead` and doesn't keep the data body. No references to the data body are retained while the operation handler is executing.
* Remove an unnecessary conversion of the response to [UInt8].

*Testing performed:* Unit tests still pass and manually tested locally to ensure requests can be received and responses returned.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
