### PR TITLE
Add Swift 5.1 CI tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=no
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=no
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE_TAG=swift:5.0.1-bionic USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 <a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-5.0-orange.svg?style=flat" alt="Swift 5.0 Compatible">
 </a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.1-orange.svg?style=flat" alt="Swift 5.1 Compatible">
+</a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">
 </a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add CI tests for Swift 5.1. Disabled SwiftLint as it currently doesn't build for Swift 5.1.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
