### PR TITLE
Remove swift 5.x compile warnings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "60bc2c4c88700ff46f2cfd1f766c4ac8319488a9",
-          "version": "1.0.0"
+          "revision": "705553c6f59d15f8b9fe2fd458a0ad3755ef9bc4",
+          "version": "1.0.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "f4240bf022a69815241a883c03645444b58ac553",
-          "version": "1.1.0"
+          "revision": "eba9b323b5ba542c119ff17382a4ce737bcdc0b8",
+          "version": "0.0.0"
         }
       },
       {

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
@@ -31,7 +31,7 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    public init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType) throws -> ()),
             allowedErrors: [(ErrorType, Int)],

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
@@ -32,7 +32,7 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    public init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
+    init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: OperationDelegate>(
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping (InputType, ContextType) throws -> OutputType,

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
@@ -31,7 +31,7 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    public init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
             allowedErrors: [(ErrorType, Int)],

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
@@ -32,7 +32,7 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    public init<InputType: Validatable, OutputType: Validatable,
+    init<InputType: Validatable, OutputType: Validatable,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType, @escaping

--- a/Sources/SmokeOperations/OperationHandlerExtensions.swift
+++ b/Sources/SmokeOperations/OperationHandlerExtensions.swift
@@ -50,7 +50,7 @@ public extension OperationHandler {
           entry is a tuple specifying the error shape and the response code to use for
           returning that error.
      */
-    public static func fromSmokeReturnableError<ShapeType>(
+    static func fromSmokeReturnableError<ShapeType>(
         error: SmokeReturnableError,
         allowedErrors: [(ShapeType, Int)])
         -> OperationFailure? where ShapeType: ErrorIdentifiableByDescription {
@@ -81,7 +81,7 @@ public extension OperationHandler {
          - request: the current request.
          - responseHandler: the response handler to use.
      */
-    public static func handleNoOutputOperationHandlerResult<ErrorType, OperationDelegateType: OperationDelegate>(
+    static func handleNoOutputOperationHandlerResult<ErrorType, OperationDelegateType: OperationDelegate>(
         handlerResult: NoOutputOperationHandlerResult<ErrorType>,
         operationDelegate: OperationDelegateType,
         requestHead: OperationDelegateType.RequestHeadType,
@@ -132,7 +132,7 @@ public extension OperationHandler {
          - request: the current request.
          - responseHandler: the response handler to use.
      */
-    public static func handleWithOutputOperationHandlerResult<OutputType, ErrorType, OperationDelegateType: OperationDelegate>(
+    static func handleWithOutputOperationHandlerResult<OutputType, ErrorType, OperationDelegateType: OperationDelegate>(
         handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>,
         operationDelegate: OperationDelegateType,
         requestHead: RequestHeadType,

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
@@ -30,7 +30,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+    mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> ()),
@@ -66,7 +66,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+    mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,
         httpMethod: HTTPMethod,
@@ -102,7 +102,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
@@ -129,7 +129,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
@@ -30,7 +30,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+    mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
@@ -78,7 +78,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+    mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,
         httpMethod: HTTPMethod,
@@ -125,7 +125,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
@@ -154,7 +154,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
@@ -30,7 +30,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+    mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
@@ -70,7 +70,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+    mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,
         httpMethod: HTTPMethod,
@@ -110,7 +110,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
@@ -141,7 +141,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
@@ -30,7 +30,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+    mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
             ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
@@ -78,7 +78,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+    mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,
         httpMethod: HTTPMethod,
@@ -125,7 +125,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
             ErrorType: ErrorIdentifiableByDescription>(
         _ uri: String,
         httpMethod: HTTPMethod,
@@ -153,7 +153,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    public mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ uri: String,
         httpMethod: HTTPMethod,

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -40,7 +40,7 @@ public extension SmokeHTTP1Server {
                               with the number of threads specified by `System.coreCount`.
      - Returns: the SmokeHTTP1Server that was created and started.
      */
-    public static func startAsOperationServer<ContextType, SelectorType>(
+    static func startAsOperationServer<ContextType, SelectorType>(
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
         andPort port: Int = ServerDefaults.defaultPort,

--- a/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
@@ -229,7 +229,13 @@ extension HTTPMethod {
 }
 
 extension HTTPMethod: Hashable {
+    #if compiler(>=5.0)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+    }
+    #else
     public var hashValue: Int {
         return rawValue.hashValue
     }
+    #endif
 }

--- a/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
@@ -229,7 +229,7 @@ extension HTTPMethod {
 }
 
 extension HTTPMethod: Hashable {
-    #if compiler(>=5.0)
+    #if swift(>=5.0) || (swift(>=4.1.50) && !swift(>=4.2)) || (swift(>=3.5) && !swift(>=4.0))
     public func hash(into hasher: inout Hasher) {
         hasher.combine(rawValue)
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Remove swift 5.x compile warnings.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
