### PR TITLE
Register handlers using a protocol rather than the raw path directly.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": "master",
-          "revision": "f4b5adf4e108d94763d8db364b3a18a322f0659e",
+          "revision": "b8126d7cea796292ded79bd748af37c58491dd26",
           "version": null
         }
       },
@@ -24,8 +24,17 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "e8aabbe95db22e064ad42f1a4a9f8982664c70ed",
-          "version": "1.1.1"
+          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "swift-metrics",
+        "repositoryURL": "https://github.com/apple/swift-metrics.git",
+        "state": {
+          "branch": null,
+          "revision": "3fefedaaef285830cc98ae80231140122076a7e0",
+          "version": "1.2.0"
         }
       },
       {

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
@@ -32,6 +32,7 @@ public extension OperationHandler {
           handling the operation.
      */
     init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            operationIdentifer: OperationIdentifer,
             inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
@@ -66,7 +67,8 @@ public extension OperationHandler {
                 responseHandler: responseHandler)
         }
         
-        self.init(inputHandler: wrappedInputHandler,
+        self.init(operationIdentifer: operationIdentifer,
+                  inputHandler: wrappedInputHandler,
                   inputProvider: inputProvider,
                   operationDelegate: operationDelegate)
     }

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
@@ -34,6 +34,7 @@ public extension OperationHandler {
      */
     init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: OperationDelegate>(
+            operationIdentifer: OperationIdentifer,
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping (InputType, ContextType) throws -> OutputType,
             outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType) -> Void),
@@ -70,7 +71,8 @@ public extension OperationHandler {
                 outputHandler: outputHandler)
         }
         
-        self.init(inputHandler: wrappedInputHandler,
+        self.init(operationIdentifer: operationIdentifer,
+                  inputHandler: wrappedInputHandler,
                   inputProvider: inputProvider,
                   operationDelegate: operationDelegate)
     }

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
@@ -32,6 +32,7 @@ public extension OperationHandler {
           handling the operation.
      */
     init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            operationIdentifer: OperationIdentifer,
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
@@ -91,7 +92,8 @@ public extension OperationHandler {
             }
         }
         
-        self.init(inputHandler: wrappedInputHandler,
+        self.init(operationIdentifer: operationIdentifer,
+                  inputHandler: wrappedInputHandler,
                   inputProvider: inputProvider,
                   operationDelegate: operationDelegate)
     }

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
@@ -34,6 +34,7 @@ public extension OperationHandler {
      */
     init<InputType: Validatable, OutputType: Validatable,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            operationIdentifer: OperationIdentifer,
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType, @escaping
                 (Swift.Result<OutputType, Swift.Error>) -> Void) throws -> Void),
@@ -98,7 +99,8 @@ public extension OperationHandler {
             }
         }
         
-        self.init(inputHandler: wrappedInputHandler,
+        self.init(operationIdentifer: operationIdentifer,
+                  inputHandler: wrappedInputHandler,
                   inputProvider: inputProvider,
                   operationDelegate: operationDelegate)
     }

--- a/Sources/SmokeOperations/OperationHandler.swift
+++ b/Sources/SmokeOperations/OperationHandler.swift
@@ -22,7 +22,7 @@ import LoggerAPI
  Struct that handles serialization and de-serialization of request and response
  bodies from and to the shapes required by operation handlers.
  */
-public struct OperationHandler<ContextType, RequestHeadType, ResponseHandlerType> {
+public struct OperationHandler<ContextType, RequestHeadType, ResponseHandlerType, OperationIdentifer: OperationIdentity> {
     public typealias OperationResultValidatableInputFunction<InputType: Validatable>
         = (_ input: InputType, _ requestHead: RequestHeadType, _ context: ContextType,
         _ responseHandler: ResponseHandlerType) -> ()
@@ -95,7 +95,8 @@ public struct OperationHandler<ContextType, RequestHeadType, ResponseHandlerType
      - Parameters:
         - operationFunction: the function to use to handle this operation.
      */
-    public init(operationFunction: @escaping OperationResultDataInputFunction) {
+    public init(operationIdentifer: OperationIdentifer,
+                operationFunction: @escaping OperationResultDataInputFunction) {
         self.operationFunction = operationFunction
     }
     
@@ -103,6 +104,7 @@ public struct OperationHandler<ContextType, RequestHeadType, ResponseHandlerType
      * Convenience initializer that incorporates decoding and validating
      */
     public init<InputType: Validatable, OperationDelegateType: OperationDelegate>(
+        operationIdentifer: OperationIdentifer,
         inputHandler: @escaping OperationResultValidatableInputFunction<InputType>,
         inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
         operationDelegate: OperationDelegateType)

--- a/Sources/SmokeOperations/OperationIdentity.swift
+++ b/Sources/SmokeOperations/OperationIdentity.swift
@@ -1,0 +1,22 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  OperationIdentity.swift
+//  SmokeOperations
+//
+
+import Foundation
+
+public protocol OperationIdentity: Hashable, CustomStringConvertible {
+    var operationPath: String { get }
+}

--- a/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
@@ -30,10 +30,11 @@ internal struct PingParameters {
  Implementation of the HttpRequestHandler protocol that handles an
  incoming Http request as an operation.
  */
-struct OperationServerHTTP1RequestHandler<ContextType, SelectorType>: HTTP1RequestHandler
+struct OperationServerHTTP1RequestHandler<ContextType, SelectorType, OperationIdentifer>: HTTP1RequestHandler
         where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
         SmokeHTTP1RequestHead == SelectorType.DefaultOperationDelegateType.RequestHeadType,
-        HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType {
+        HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType,
+        SelectorType.OperationIdentifer == OperationIdentifer {
     let handlerSelector: SelectorType
     let context: ContextType
 
@@ -53,7 +54,7 @@ struct OperationServerHTTP1RequestHandler<ContextType, SelectorType>: HTTP1Reque
         let query = uriComponents.count > 1 ? String(uriComponents[1]) : ""
 
         // get the handler to use
-        let handler: OperationHandler<ContextType, SmokeHTTP1RequestHead, HTTP1ResponseHandler>
+        let handler: OperationHandler<ContextType, SmokeHTTP1RequestHead, HTTP1ResponseHandler, OperationIdentifer>
         let shape: Shape
         let defaultOperationDelegate = handlerSelector.defaultOperationDelegate
         

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
@@ -30,8 +30,8 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
-        _ uri: String,
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
@@ -47,12 +47,13 @@ public extension SmokeHTTP1HandlerSelector {
         }
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: inputProvider,
             operation: operation,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -66,9 +67,9 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
@@ -85,12 +86,13 @@ public extension SmokeHTTP1HandlerSelector {
             }
             
             let handler = OperationHandler(
+                operationIdentifer: operationIdentifer,
                 inputProvider: inputProvider,
                 operation: operation,
                 allowedErrors: allowedErrors,
                 operationDelegate: operationDelegate)
             
-            addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -102,20 +104,21 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> ()),
         allowedErrors: [(ErrorType, Int)]) {
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: defaultOperationDelegate.getInputForOperation,
             operation: operation,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -129,10 +132,10 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
@@ -141,11 +144,12 @@ public extension SmokeHTTP1HandlerSelector {
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: operationDelegate.getInputForOperation,
             operation: operation,
             allowedErrors: allowedErrors,
             operationDelegate: operationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
@@ -30,9 +30,9 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)],
@@ -58,13 +58,14 @@ public extension SmokeHTTP1HandlerSelector {
         }
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: inputProvider,
             operation: operation,
             outputHandler: outputHandler,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -78,9 +79,9 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)],
@@ -107,13 +108,14 @@ public extension SmokeHTTP1HandlerSelector {
             }
             
             let handler = OperationHandler(
+                operationIdentifer: operationIdentifer,
                 inputProvider: inputProvider,
                 operation: operation,
                 outputHandler: outputHandler,
                 allowedErrors: allowedErrors,
                 operationDelegate: operationDelegate)
             
-            addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -125,22 +127,23 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)]) {
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: defaultOperationDelegate.getInputForOperation,
             operation: operation,
             outputHandler: defaultOperationDelegate.handleResponseForOperation,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -154,10 +157,10 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)],
@@ -166,12 +169,13 @@ public extension SmokeHTTP1HandlerSelector {
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: operationDelegate.getInputForOperation,
             operation: operation,
             outputHandler: operationDelegate.handleResponseForOperation,
             allowedErrors: allowedErrors,
             operationDelegate: operationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
@@ -30,8 +30,8 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
-        _ uri: String,
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
@@ -51,12 +51,13 @@ public extension SmokeHTTP1HandlerSelector {
         }
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: inputProvider,
             operation: operation,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -70,9 +71,9 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    mutating func addHandlerForUri<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
@@ -93,12 +94,13 @@ public extension SmokeHTTP1HandlerSelector {
             }
             
             let handler = OperationHandler(
+                operationIdentifer: operationIdentifer,
                 inputProvider: inputProvider,
                 operation: operation,
                 allowedErrors: allowedErrors,
                 operationDelegate: operationDelegate)
             
-            addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -110,9 +112,9 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)]) {
@@ -122,12 +124,13 @@ public extension SmokeHTTP1HandlerSelector {
         }
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: defaultOperationDelegate.getInputForOperation,
             operation: operation,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -141,10 +144,10 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol,
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
@@ -157,11 +160,12 @@ public extension SmokeHTTP1HandlerSelector {
         }
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: operationDelegate.getInputForOperation,
             operation: operation,
             allowedErrors: allowedErrors,
             operationDelegate: operationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
@@ -30,9 +30,9 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
             ErrorType: ErrorIdentifiableByDescription>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Result<OutputType, Swift.Error>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
@@ -58,13 +58,14 @@ public extension SmokeHTTP1HandlerSelector {
         }
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: inputProvider,
             operation: operation,
             outputHandler: outputHandler,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -78,9 +79,9 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    mutating func addHandlerForUri<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Result<OutputType, Swift.Error>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
@@ -107,13 +108,14 @@ public extension SmokeHTTP1HandlerSelector {
             }
             
             let handler = OperationHandler(
+                operationIdentifer: operationIdentifer,
                 inputProvider: inputProvider,
                 operation: operation,
                 outputHandler: outputHandler,
                 allowedErrors: allowedErrors,
                 operationDelegate: operationDelegate)
             
-            addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -125,21 +127,22 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
             ErrorType: ErrorIdentifiableByDescription>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Result<OutputType, Swift.Error>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)]) {
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: defaultOperationDelegate.getInputForOperation,
             operation: operation,
             outputHandler: defaultOperationDelegate.handleResponseForOperation,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
     
     /**
@@ -153,9 +156,9 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    mutating func addHandlerForUri<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
-        _ uri: String,
+        _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
         operation: @escaping ((InputType, ContextType, @escaping (Swift.Result<OutputType, Swift.Error>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
@@ -164,12 +167,13 @@ public extension SmokeHTTP1HandlerSelector {
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(
+            operationIdentifer: operationIdentifer,
             inputProvider: operationDelegate.getInputForOperation,
             operation: operation,
             outputHandler: operationDelegate.handleResponseForOperation,
             allowedErrors: allowedErrors,
             operationDelegate: operationDelegate)
         
-        addHandlerForUri(uri, httpMethod: httpMethod, handler: handler)
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
@@ -26,6 +26,7 @@ import ShapeCoding
 public protocol SmokeHTTP1HandlerSelector {
     associatedtype ContextType
     associatedtype DefaultOperationDelegateType: HTTP1OperationDelegate
+    associatedtype OperationIdentifer: OperationIdentity
     
     /// Get the instance of the Default OperationDelegate type
     var defaultOperationDelegate: DefaultOperationDelegateType { get }
@@ -40,7 +41,8 @@ public protocol SmokeHTTP1HandlerSelector {
     func getHandlerForOperation(_ uri: String, httpMethod: HTTPMethod) throws
         -> (OperationHandler<ContextType,
             DefaultOperationDelegateType.RequestHeadType,
-            DefaultOperationDelegateType.ResponseHandlerType>, Shape)
+            DefaultOperationDelegateType.ResponseHandlerType,
+            OperationIdentifer>, Shape)
     
     /**
      Adds a handler for the specified uri and http method.
@@ -50,9 +52,10 @@ public protocol SmokeHTTP1HandlerSelector {
         - httpMethod: the http method to add the handler for.
         - handler: the handler to add.
      */
-    mutating func addHandlerForUri(_ uri: String,
-                                   httpMethod: HTTPMethod,
-                                   handler: OperationHandler<ContextType,
-                                    DefaultOperationDelegateType.RequestHeadType,
-                                    DefaultOperationDelegateType.ResponseHandlerType>)
+    mutating func addHandlerForOperation(_ operationIdentifer: OperationIdentifer,
+                                         httpMethod: HTTPMethod,
+                                         handler: OperationHandler<ContextType,
+                                            DefaultOperationDelegateType.RequestHeadType,
+                                            DefaultOperationDelegateType.ResponseHandlerType,
+                                            OperationIdentifer>)
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -42,7 +42,7 @@ public extension SmokeHTTP1Server {
                              If not specified, the server will be shutdown if a SIGINT is received.
      - Returns: the SmokeHTTP1Server that was created and started.
      */
-    static func startAsOperationServer<ContextType, SelectorType>(
+    static func startAsOperationServer<ContextType, SelectorType, OperationIdentifer>(
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
         andPort port: Int = ServerDefaults.defaultPort,
@@ -51,7 +51,8 @@ public extension SmokeHTTP1Server {
         shutdownOnSignal: ShutdownOnSignal = .sigint) throws -> SmokeHTTP1Server
         where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
         SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
-        SelectorType.DefaultOperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler {
+        SelectorType.DefaultOperationDelegateType.ResponseHandlerType == HTTP1ResponseHandler,
+        SelectorType.OperationIdentifer == OperationIdentifer {
             let handler = OperationServerHTTP1RequestHandler(
                 handlerSelector: handlerSelector,
                 context: context)

--- a/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
@@ -26,12 +26,14 @@ import ShapeCoding
  Implementation of the SmokeHTTP1HandlerSelector protocol that selects a handler
  based on the case-insensitive uri and HTTP method of the incoming request.
  */
-public struct StandardSmokeHTTP1HandlerSelector<ContextType, DefaultOperationDelegateType: HTTP1OperationDelegate>: SmokeHTTP1HandlerSelector {
+public struct StandardSmokeHTTP1HandlerSelector<ContextType, DefaultOperationDelegateType: HTTP1OperationDelegate,
+        OperationIdentifer: OperationIdentity>: SmokeHTTP1HandlerSelector {
     public let defaultOperationDelegate: DefaultOperationDelegateType
     
     public typealias SelectorOperationHandlerType = OperationHandler<ContextType,
             DefaultOperationDelegateType.RequestHeadType,
-            DefaultOperationDelegateType.ResponseHandlerType>
+            DefaultOperationDelegateType.ResponseHandlerType,
+            OperationIdentifer>
     
     private struct TokenizedHandler {
         let template: String
@@ -108,9 +110,11 @@ public struct StandardSmokeHTTP1HandlerSelector<ContextType, DefaultOperationDel
         - httpMethod: the http method to add the handler for.
         - handler: the handler to add.
      */
-    public mutating func addHandlerForUri(_ uri: String,
-                                          httpMethod: HTTPMethod,
-                                          handler: SelectorOperationHandlerType) {
+    public mutating func addHandlerForOperation(_ operationIdentifer: OperationIdentifer,
+                                                httpMethod: HTTPMethod,
+                                                handler: SelectorOperationHandlerType) {
+        let uri = operationIdentifer.operationPath
+        
         if addTokenizedUri(uri, httpMethod: httpMethod, handler: handler) {
             return
         }

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
@@ -100,89 +100,89 @@ func handleBadHTTP1OperationAsyncWithThrow(input: ExampleHTTP1Input, context: Ex
     throw MyError.theError(reason: "Is bad!")
 }
 
-fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate> = {
+fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate, TestOperations> = {
     let defaultOperationDelegate = JSONPayloadHTTP1OperationDelegate()
-    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate>(
+    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate, TestOperations>(
         defaultOperationDelegate: defaultOperationDelegate)
     
-    newHandlerSelector.addHandlerForUri(
-        "exampleoperation", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleOperation, httpMethod: .POST,
         operation: handleExampleOperationAsync,
         allowedErrors: allowedErrors,
         inputLocation: .body,
         outputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "exampleoperation/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleOperationWithToken, httpMethod: .POST,
         operation: handleExampleHTTP1OperationAsync,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "examplegetoperation", httpMethod: .GET,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleGetOperation, httpMethod: .GET,
         operation: handleExampleOperationAsync,
         allowedErrors: allowedErrors,
         inputLocation: .body,
         outputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "examplegetoperation/{theToken}", httpMethod: .GET,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleGetOperationWithToken, httpMethod: .GET,
         operation: handleExampleHTTP1OperationAsync,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "examplenobodyoperation", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleNoBodyOperation, httpMethod: .POST,
         operation: handleExampleOperationVoidAsync,
         allowedErrors: allowedErrors,
         inputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "examplenobodyoperation/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleNoBodyOperationWithToken, httpMethod: .POST,
         operation: handleExampleHTTP1OperationVoidAsync,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperationvoidresponse", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationVoidResponse, httpMethod: .POST,
         operation: handleBadOperationVoidAsync,
         allowedErrors: allowedErrors,
         inputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperationvoidresponse/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationVoidResponseWithToken, httpMethod: .POST,
         operation: handleBadHTTP1OperationVoidAsync,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperationvoidresponsewiththrow", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationVoidResponseWithThrow, httpMethod: .POST,
         operation: handleBadOperationVoidAsyncWithThrow,
         allowedErrors: allowedErrors,
         inputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperationvoidresponsewiththrow/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationVoidResponseWithThrowWithToken, httpMethod: .POST,
         operation: handleBadHTTP1OperationVoidAsyncWithThrow,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperation", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperation, httpMethod: .POST,
         operation: handleBadOperationAsync,
         allowedErrors: allowedErrors,
         inputLocation: .body,
         outputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperation/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationWithToken, httpMethod: .POST,
         operation: handleBadHTTP1OperationAsync,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperationwiththrow", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationWithThrow, httpMethod: .POST,
         operation: handleBadOperationAsync,
         allowedErrors: allowedErrors,
         inputLocation: .body,
         outputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperationwiththrow/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationWithThrowWithToken, httpMethod: .POST,
         operation: handleBadHTTP1OperationAsync,
         allowedErrors: allowedErrors)
     

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
@@ -58,64 +58,118 @@ func handleBadHTTP1Operation(input: ExampleHTTP1Input, context: ExampleContext) 
     throw MyError.theError(reason: "Is bad!")
 }
 
-fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate> = {
-    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate>(
+enum TestOperations: String, OperationIdentity {
+    case exampleOperation
+    case exampleOperationWithToken
+    case exampleGetOperation
+    case exampleGetOperationWithToken
+    case exampleNoBodyOperation
+    case exampleNoBodyOperationWithToken
+    case badOperation
+    case badOperationWithToken
+    case badOperationVoidResponse
+    case badOperationVoidResponseWithToken
+    case badOperationWithThrow
+    case badOperationWithThrowWithToken
+    case badOperationVoidResponseWithThrow
+    case badOperationVoidResponseWithThrowWithToken
+    
+    var description: String {
+        return rawValue
+    }
+    
+    var operationPath: String {
+        switch self {
+        case .exampleOperation:
+            return "exampleoperation"
+        case .exampleOperationWithToken:
+            return "exampleoperation/{theToken}"
+        case .exampleGetOperation:
+            return "examplegetoperation"
+        case .exampleGetOperationWithToken:
+            return "examplegetoperation/{theToken}"
+        case .exampleNoBodyOperation:
+            return "examplenobodyoperation"
+        case .exampleNoBodyOperationWithToken:
+            return "examplenobodyoperation/{theToken}"
+        case .badOperation:
+            return "badoperation"
+        case .badOperationWithToken:
+            return "badoperation/{theToken}"
+        case .badOperationVoidResponse:
+            return "badoperationvoidresponse"
+        case .badOperationVoidResponseWithToken:
+            return "badoperationvoidresponse/{theToken}"
+        case .badOperationWithThrow:
+            return "badoperationwiththrow"
+        case .badOperationWithThrowWithToken:
+            return "badoperationwiththrow/{theToken}"
+        case .badOperationVoidResponseWithThrow:
+            return "badoperationvoidresponsewiththrow"
+        case .badOperationVoidResponseWithThrowWithToken:
+            return "badoperationvoidresponsewiththrow/{theToken}"
+        }
+    }
+}
+
+fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate, TestOperations> = {
+    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate, TestOperations>(
         defaultOperationDelegate: JSONPayloadHTTP1OperationDelegate())
-    newHandlerSelector.addHandlerForUri(
-        "exampleoperation", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleOperation, httpMethod: .POST,
         operation: handleExampleOperation,
         allowedErrors: allowedErrors,
         inputLocation: .body,
         outputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "exampleoperation/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleOperationWithToken, httpMethod: .POST,
         operation: handleExampleHTTP1Operation,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "examplegetoperation", httpMethod: .GET,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleGetOperation, httpMethod: .GET,
         operation: handleExampleOperation,
         allowedErrors: allowedErrors,
         inputLocation: .body,
         outputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "examplegetoperation/{theToken}", httpMethod: .GET,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleGetOperationWithToken, httpMethod: .GET,
         operation: handleExampleHTTP1Operation,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "examplenobodyoperation", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleNoBodyOperation, httpMethod: .POST,
         operation: handleExampleOperationVoid,
         allowedErrors: allowedErrors,
         inputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "examplenobodyoperation/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .exampleNoBodyOperationWithToken, httpMethod: .POST,
         operation: handleExampleHTTP1OperationVoid,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperation", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperation, httpMethod: .POST,
         operation: handleBadOperation,
         allowedErrors: allowedErrors,
         inputLocation: .body,
         outputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperation/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationWithToken, httpMethod: .POST,
         operation: handleBadHTTP1Operation,
         allowedErrors: allowedErrors)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperationvoidresponse", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationVoidResponse, httpMethod: .POST,
         operation: handleBadOperationVoid,
         allowedErrors: allowedErrors,
         inputLocation: .body)
     
-    newHandlerSelector.addHandlerForUri(
-        "badoperationvoidresponse/{theToken}", httpMethod: .POST,
+    newHandlerSelector.addHandlerForOperation(
+        .badOperationVoidResponseWithToken, httpMethod: .POST,
         operation: handleBadHTTP1OperationVoid,
         allowedErrors: allowedErrors)
     

--- a/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
@@ -230,8 +230,9 @@ func verifyPathOutput<SelectorType>(uri: String, body: Data,
                                     additionalHeaders: [(String, String)] = []) -> OperationResponse
 where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ExampleContext,
     SmokeHTTP1RequestHead == SelectorType.DefaultOperationDelegateType.RequestHeadType,
-    HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType {
-    let handler = OperationServerHTTP1RequestHandler<ExampleContext, SelectorType>(
+    HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType,
+    SelectorType.OperationIdentifer == TestOperations {
+    let handler = OperationServerHTTP1RequestHandler<ExampleContext, SelectorType, TestOperations>(
         handlerSelector: handlerSelector,
         context: ExampleContext())
     
@@ -256,7 +257,8 @@ func verifyErrorResponse<SelectorType>(uri: String,
                                        additionalHeaders: [(String, String)] = []) throws
 where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ExampleContext,
     SmokeHTTP1RequestHead == SelectorType.DefaultOperationDelegateType.RequestHeadType,
-    HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType {
+    HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType,
+    SelectorType.OperationIdentifer == TestOperations {
     let response = verifyPathOutput(uri: uri,
                                     body: serializedAlternateInput.data(using: .utf8)!,
                                     handlerSelector: handlerSelector,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add the OperationIdentity protocol and register handlers under instances of this protocol rather than the url directly. This allows handlers to be registered using an enumeration for example to reduce the change of typos causing incorrect handler selection.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
