### PR TITLE
Operation handlers that accept the SmokeServerInvocationContext

### DIFF
--- a/Sources/SmokeOperations/OperationHandler+blockingWithContextInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithContextInputNoOutput.swift
@@ -1,0 +1,76 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OperationHandler+blockingWithContextInputNoOutput.swift
+// SmokeOperations
+//
+
+import Foundation
+import Logging
+
+public extension OperationHandler {
+    /**
+       Initializer for blocking operation handler that has input returns
+       a result with an empty body.
+     
+     - Parameters:
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it so that if it
+         * returns, the responseHandler is called to indicate success. If the provided operation
+         * throws an error, the responseHandler is called with that error.
+         */
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
+            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext) in
+            let handlerResult: NoOutputOperationHandlerResult<ErrorType>
+            do {
+                try operation(input, context, invocationContext.invocationReporting)
+                
+                handlerResult = .success
+            } catch let smokeReturnableError as SmokeReturnableError {
+                handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+            } catch SmokeOperationsError.validationError(reason: let reason) {
+                handlerResult = .validationError(reason)
+            } catch {
+                handlerResult = .internalServerError(error)
+            }
+            
+            OperationHandler.handleNoOutputOperationHandlerResult(
+                handlerResult: handlerResult,
+                operationDelegate: operationDelegate,
+                requestHead: requestHead,
+                responseHandler: responseHandler,
+                invocationContext: invocationContext)
+        }
+        
+        self.init(serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeOperations/OperationHandler+blockingWithContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithContextInputWithOutput.swift
@@ -1,0 +1,81 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OperationHandler+blockingWithContextInputWithOutput.swift
+// SmokeOperations
+//
+
+import Foundation
+import Logging
+
+public extension OperationHandler {
+    /**
+      Initializer for blocking operation handler that has input returns
+      a result body.
+     
+     - Parameters:
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping (InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType,
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext) -> Void),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it so that if it
+         * returns, the responseHandler is called with the result. If the provided operation
+         * throws an error, the responseHandler is called with that error.
+         */
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
+                                     responseHandler: OperationDelegateType.ResponseHandlerType,
+                                     invocationContext: SmokeServerInvocationContext) in
+            let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
+            do {
+                let output = try operation(input, context, invocationContext.invocationReporting)
+                
+                handlerResult = .success(output)
+            } catch let smokeReturnableError as SmokeReturnableError {
+                handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+            } catch SmokeOperationsError.validationError(reason: let reason) {
+                handlerResult = .validationError(reason)
+            } catch {
+                handlerResult = .internalServerError(error)
+            }
+            
+            OperationHandler.handleWithOutputOperationHandlerResult(
+                handlerResult: handlerResult,
+                operationDelegate: operationDelegate,
+                requestHead: requestHead,
+                responseHandler: responseHandler,
+                outputHandler: outputHandler,
+                invocationContext: invocationContext)
+        }
+        
+        self.init(serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithContextInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithContextInputNoOutput.swift
@@ -1,0 +1,102 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OperationHandler+nonblockingWithContextInputNoOutput.swift
+// SmokeOperations
+//
+
+import Foundation
+import Logging
+
+public extension OperationHandler {
+    /**
+       Initializer for non-blocking operation handler that has input
+       returns a result with an empty body.
+     
+     - Parameters:
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it the responseHandler is
+         * called to indicate success when the input handler's response handler is called. If the provided operation
+         * provides an error, the responseHandler is called with that error.
+         */
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
+            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext) in
+            let handlerResult: NoOutputOperationHandlerResult<ErrorType>?
+            do {
+                try operation(input, context, invocationContext.invocationReporting) { error in
+                    let asyncHandlerResult: NoOutputOperationHandlerResult<ErrorType>
+                    
+                    if let error = error {
+                        if let smokeReturnableError = error as? SmokeReturnableError {
+                            asyncHandlerResult = .smokeReturnableError(smokeReturnableError,
+                                                                       allowedErrors)
+                        } else if case SmokeOperationsError.validationError(reason: let reason) = error {
+                            asyncHandlerResult = .validationError(reason)
+                        } else {
+                            asyncHandlerResult = .internalServerError(error)
+                        }
+                    } else {
+                        asyncHandlerResult = .success
+                    }
+                    
+                    OperationHandler.handleNoOutputOperationHandlerResult(
+                        handlerResult: asyncHandlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        invocationContext: invocationContext)
+                }
+                
+                // no immediate result
+                handlerResult = nil
+            } catch let smokeReturnableError as SmokeReturnableError {
+                handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+            } catch SmokeOperationsError.validationError(reason: let reason) {
+                handlerResult = .validationError(reason)
+            } catch {
+                handlerResult = .internalServerError(error)
+            }
+            
+            // if this handler is throwing an error immediately
+            if let handlerResult = handlerResult {
+                OperationHandler.handleNoOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithContextInputWithOutput.swift
@@ -1,0 +1,109 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  OperationHandler+nonblockingWithContextInputWithOutput.swift
+//  SmokeOperations
+//
+
+import Foundation
+import Logging
+
+public extension OperationHandler {
+    /**
+       Initializer for non-blocking operation handler that has input
+       returns a result body.
+     
+     - Parameters:
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, OutputType: Validatable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping
+                (Result<OutputType, Swift.Error>) -> Void) throws -> Void),
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext) -> Void),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it the responseHandler is
+         * called with the result when the input handler's response handler is called. If the provided operation
+         * provides an error, the responseHandler is called with that error.
+         */
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
+            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext) in
+            let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>?
+            do {
+                try operation(input, context, invocationContext.invocationReporting) { result in
+                    let asyncHandlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
+                    
+                    switch result {
+                    case .success(let result):
+                        asyncHandlerResult = .success(result)
+                    case .failure(let error):
+                        if let smokeReturnableError = error as? SmokeReturnableError {
+                            asyncHandlerResult = .smokeReturnableError(smokeReturnableError,
+                                                                       allowedErrors)
+                        } else if case SmokeOperationsError.validationError(reason: let reason) = error {
+                            asyncHandlerResult = .validationError(reason)
+                        } else {
+                            asyncHandlerResult = .internalServerError(error)
+                        }
+                    }
+                    
+                    OperationHandler.handleWithOutputOperationHandlerResult(
+                        handlerResult: asyncHandlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        outputHandler: outputHandler,
+                        invocationContext: invocationContext)
+                }
+                
+                // no immediate result
+                handlerResult = nil
+            } catch let smokeReturnableError as SmokeReturnableError {
+                handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+            } catch SmokeOperationsError.validationError(reason: let reason) {
+                handlerResult = .validationError(reason)
+            } catch {
+                handlerResult = .internalServerError(error)
+            }
+            
+            // if this handler is throwing an error immediately
+            if let handlerResult = handlerResult {
+                OperationHandler.handleWithOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    outputHandler: outputHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithContextInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithContextInputNoOutput.swift
@@ -1,0 +1,155 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+blockingWithContextInputNoOutput.swift
+// SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithContextInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithContextInputWithOutput.swift
@@ -1,0 +1,185 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+blockingWithContextInputWithOutput.swift
+// SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
+                           output: OutputType,
+                           responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
+                           invocationContext: SmokeServerInvocationContext) {
+            delegateToUse.handleResponseForOperation(requestHead: requestHead,
+                                                     location: outputLocation,
+                                                     output: output,
+                                                     responseHandler: responseHandler,
+                                                     invocationContext: invocationContext)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            outputHandler: outputHandler,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
+                               output: OutputType,
+                               responseHandler: OperationDelegateType.ResponseHandlerType,
+                               invocationContext: SmokeServerInvocationContext) {
+                operationDelegate.handleResponseForOperation(requestHead: requestHead,
+                                                             location: outputLocation,
+                                                             output: output,
+                                                             responseHandler: responseHandler,
+                                                             invocationContext: invocationContext)
+            }
+            
+            let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                outputHandler: outputHandler,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        OutputType: ValidatableOperationHTTP1OutputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: defaultOperationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        OutputType: ValidatableOperationHTTP1OutputProtocol,
+        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: operationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithContextInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithContextInputNoOutput.swift
@@ -1,0 +1,175 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+nonblockingWithContextInputNoOutput.swift
+// SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation) {
+        
+        func outputProvider(input: InputType, context: ContextType,
+                            invocationReporting: SmokeServerInvocationReporting, completion: @escaping (Swift.Error?) -> ()) throws {
+            try operation(input, context, invocationReporting, completion)
+        }
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func outputProvider(input: InputType, context: ContextType,
+                                invocationReporting: SmokeServerInvocationReporting, completion: @escaping (Swift.Error?) -> ()) throws {
+                try operation(input, context, invocationReporting, completion)
+            }
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        func outputProvider(input: InputType, context: ContextType,
+                            invocationReporting: SmokeServerInvocationReporting, completion: @escaping (Swift.Error?) -> ()) throws {
+            try operation(input, context, invocationReporting, completion)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        func outputProvider(input: InputType, context: ContextType,
+                            invocationReporting: SmokeServerInvocationReporting, completion: @escaping (Swift.Error?) -> ()) throws {
+            try operation(input, context, invocationReporting, completion)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithContextInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithContextInputWithOutput.swift
@@ -1,0 +1,183 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  SmokeHTTP1HandlerSelector+nonblockingWithContextInputWithOutput.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
+                           output: OutputType,
+                           responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
+                           invocationContext: SmokeServerInvocationContext) {
+            delegateToUse.handleResponseForOperation(requestHead: requestHead,
+                                                     location: outputLocation,
+                                                     output: output,
+                                                     responseHandler: responseHandler,
+                                                     invocationContext: invocationContext)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            outputHandler: outputHandler,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
+                               output: OutputType,
+                               responseHandler: OperationDelegateType.ResponseHandlerType,
+                               invocationContext: SmokeServerInvocationContext) {
+                operationDelegate.handleResponseForOperation(requestHead: requestHead,
+                                                             location: outputLocation,
+                                                             output: output,
+                                                             responseHandler: responseHandler,
+                                                             invocationContext: invocationContext)
+            }
+            
+            let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                outputHandler: outputHandler,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: defaultOperationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: operationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}


### PR DESCRIPTION
Add support for operation handlers that accept the SmokeServerInvocationContext.

*Issue #, if available:*

*Description of changes:* Add extensions to SmokeHTTP1HandlerSelector and OperationHandler to support operation handler signatures that accept the SmokeServerInvocationContext for access to for example the request logger.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
