### PR TITLE
Infrastructure for request tracing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,16 @@ matrix:
       sudo: required
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.0.3-xenial USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-master-xenial USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-5.2-xenial USE_SWIFT_LINT=yes
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1.3-bionic USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.1.4-bionic USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1.3-xenial USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.1.4-xenial USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,22 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.1.3-bionic USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.1.3-xenial USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.0.1-bionic USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.0.3-bionic USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.0.1-xenial USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.0.3-xenial USE_SWIFT_LINT=yes
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,6 @@ matrix:
       sudo: required
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.0.3-xenial USE_SWIFT_LINT=yes
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-master-xenial USE_SWIFT_LINT=yes
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-5.2-xenial USE_SWIFT_LINT=yes
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/CITests/run
+++ b/CITests/run
@@ -22,8 +22,8 @@ if [ "$USE_SWIFT_LINT" == 'yes' ]; then
 fi
 
 cd $workspaceRoot/package
-swift build
-swift test
+swift build -c release
+#swift test
 
 if [ "$USE_SWIFT_LINT" == 'yes' ]; then
     swiftlint

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,9 @@ let package = Package(
             name: "SmokeOperationsHTTP1",
             targets: ["SmokeOperationsHTTP1"]),
         .library(
+            name: "SmokeInvocation",
+            targets: ["SmokeInvocation"]),
+        .library(
             name: "SmokeHTTP1",
             targets: ["SmokeHTTP1"]),
     ],
@@ -40,11 +43,14 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "SmokeInvocation",
+            dependencies: ["Logging"]),
+        .target(
             name: "SmokeHTTP1",
-            dependencies: ["NIO", "NIOHTTP1", "NIOFoundationCompat", "NIOExtras", "SmokeOperations", "Logging"]),
+            dependencies: ["NIO", "NIOHTTP1", "NIOFoundationCompat", "NIOExtras", "Logging", "SmokeInvocation"]),
         .target(
             name: "SmokeOperations",
-            dependencies: ["Logging", "Metrics"]),
+            dependencies: ["Logging", "Metrics", "SmokeInvocation"]),
         .target(
             name: "SmokeOperationsHTTP1",
             dependencies: ["SmokeOperations", "SmokeHTTP1", "QueryCoding",

--- a/Sources/SmokeHTTP1/HTTP1RequestHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1RequestHandler.swift
@@ -18,13 +18,15 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import SmokeOperations
 import Logging
+import SmokeInvocation
 
 /**
  Protocol that specifies a handler for a HttpRequest.
  */
 public protocol HTTP1RequestHandler {
+    associatedtype ResponseHandlerType: HTTP1ResponseHandler
+    
     /**
      Handles an incoming request.
  
@@ -34,6 +36,6 @@ public protocol HTTP1RequestHandler {
         - responseHandler: a handler that can be used to respond to the request.
         - invocationStrategy: the invocationStrategy to use for this request.
      */
-    func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: HTTP1ResponseHandler,
+    func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                 invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String)
 }

--- a/Sources/SmokeHTTP1/HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeHTTP1/HTTP1RequestInvocationContext.swift
@@ -11,26 +11,17 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  GlobalDispatchQueueAsyncInvocationStrategy.swift
-//  SmokeOperations
+//  HTTP1RequestTraceContext.swift
+//  SmokeHTTP1
 //
 
 import Foundation
+import Logging
+import NIOHTTP1
 
-/**
- An InvocationStrategy that will invocate the handler on
- DispatchQueue.global(), waiting for it to complete.
- */
-public struct GlobalDispatchQueueSyncInvocationStrategy: InvocationStrategy {
-    let queue = DispatchQueue.global()
+public protocol HTTP1RequestInvocationContext {
     
-    public init() {
-        
-    }
+    var logger: Logger { get }
     
-    public func invoke(handler: @escaping () -> ()) {
-        queue.sync {
-            handler()
-        }
-    }
+    func decorateResponseHeaders(httpHeaders: inout HTTPHeaders)
 }

--- a/Sources/SmokeHTTP1/HTTP1ResponseHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1ResponseHandler.swift
@@ -24,6 +24,7 @@ import SmokeOperations
  A protocol that specifies a handler for a HTTP response.
  */
 public protocol HTTP1ResponseHandler {
+    associatedtype InvocationContext: HTTP1RequestInvocationContext
     
     /**
      Function used to provide a response to a HTTP request.
@@ -33,7 +34,7 @@ public protocol HTTP1ResponseHandler {
         - status: the status to provide in the response.
         - responseComponents: the components to send in the response.
      */
-    func complete(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
+    func complete(invocationContext: InvocationContext, status: HTTPResponseStatus,
                   responseComponents: HTTP1ServerResponseComponents)
     
     /**
@@ -44,7 +45,7 @@ public protocol HTTP1ResponseHandler {
         - status: the status to provide in the response.
         - responseComponents: the components to send in the response.
      */
-    func completeInEventLoop(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
+    func completeInEventLoop(invocationContext: InvocationContext, status: HTTPResponseStatus,
                              responseComponents: HTTP1ServerResponseComponents)
     
     /**
@@ -56,7 +57,7 @@ public protocol HTTP1ResponseHandler {
         - status: the status to provide in the response.
         - body: the content type and data to use for the response.
      */
-    func completeSilently(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
+    func completeSilently(invocationContext: InvocationContext, status: HTTPResponseStatus,
                           responseComponents: HTTP1ServerResponseComponents)
     
     /**
@@ -68,7 +69,7 @@ public protocol HTTP1ResponseHandler {
         - status: the status to provide in the response.
         - body: the content type and data to use for the response.
      */
-    func completeSilentlyInEventLoop(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
+    func completeSilentlyInEventLoop(invocationContext: InvocationContext, status: HTTPResponseStatus,
                                      responseComponents: HTTP1ServerResponseComponents)
     
     /**
@@ -78,11 +79,11 @@ public protocol HTTP1ResponseHandler {
         - invocationContext: the context for the current invocation.
         - execute: the closure to execute.
      */
-    func executeInEventLoop(invocationContext: SmokeServerInvocationContext, execute: @escaping () -> ())
+    func executeInEventLoop(invocationContext: InvocationContext, execute: @escaping () -> ())
 }
 
 public extension HTTP1ResponseHandler {
-    func completeSilently(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
+    func completeSilently(invocationContext: InvocationContext, status: HTTPResponseStatus,
                           responseComponents: HTTP1ServerResponseComponents) {
         complete(invocationContext: invocationContext, status: status, responseComponents: responseComponents)
     }

--- a/Sources/SmokeHTTP1/SmokeHTTP1Server.swift
+++ b/Sources/SmokeHTTP1/SmokeHTTP1Server.swift
@@ -19,231 +19,56 @@ import Foundation
 import NIO
 import NIOHTTP1
 import NIOExtras
-import SmokeOperations
 import Logging
+import SmokeInvocation
 
-public struct ServerDefaults {
-    static let defaultHost = "0.0.0.0"
-    public static let defaultPort = 8080
+/**
+ Enumeration specifying how the event loop is provided for a channel established by this client.
+ */
+public enum SmokeServerEventLoopProvider {
+    /// The client will create a new EventLoopGroup to be used for channels created from
+    /// this client. The EventLoopGroup will be closed when this client is closed.
+    case spawnNewThreads
+    /// The client will use the provided EventLoopGroup for channels created from
+    /// this client. This EventLoopGroup will not be closed when this client is closed.
+    case use(EventLoopGroup)
 }
 
-public enum SmokeHTTP1ServerError: Error {
-    case shutdownAttemptOnUnstartedServer
+/**
+ Enumeration specifying if the server should be shutdown on any signals received.
+ */
+public enum SmokeServerShutdownOnSignal {
+    // do not shut down the server on any signals
+    case none
+    // shutdown the server if a SIGINT is received
+    case sigint
+    // shutdown the server if a SIGTERM is received
+    case sigterm
 }
 
 /**
  A basic non-blocking HTTP server that handles a request with an
  optional body and returns a response with an optional body.
  */
-public class SmokeHTTP1Server {
-    let port: Int
-    
-    let quiesce: ServerQuiescingHelper
-    let signalSource: DispatchSourceSignal?
-    let fullyShutdownPromise: EventLoopPromise<Void>
-    let handler: HTTP1RequestHandler
-    let invocationStrategy: InvocationStrategy
-    var channel: Channel?
-    let defaultLogger: Logger
-    let shutdownDispatchGroup: DispatchGroup
-    let shutdownCompletionHandlerInvocationStrategy: InvocationStrategy
-    
-    enum State {
-        case initialized
-        case running
-        case shuttingDown
-        case shutDown
-    }
-    private var shutdownCompletionHandlers: [() -> Void] = []
-    private var serverState: State = .initialized
-    private var stateLock: NSLock = NSLock()
-    
-    /**
-     Enumeration specifying how the event loop is provided for a channel established by this client.
-     */
-    public enum EventLoopProvider {
-        /// The client will create a new EventLoopGroup to be used for channels created from
-        /// this client. The EventLoopGroup will be closed when this client is closed.
-        case spawnNewThreads
-        /// The client will use the provided EventLoopGroup for channels created from
-        /// this client. This EventLoopGroup will not be closed when this client is closed.
-        case use(EventLoopGroup)
-    }
-    
-    /**
-     Enumeration specifying if the server should be shutdown on any signals received.
-     */
-    public enum ShutdownOnSignal {
-        // do not shut down the server on any signals
-        case none
-        // shutdown the server if a SIGINT is received
-        case sigint
-        // shutdown the server if a SIGTERM is received
-        case sigterm
-    }
-    
-    let eventLoopGroup: EventLoopGroup
-    let ownEventLoopGroup: Bool
-    
-    /**
-     Initializer.
- 
-     - Parameters:
-        - handler: the HTTPRequestHandler to handle incoming requests.
-        - port: Optionally the localhost port for the server to listen on.
-                If not specified, defaults to 8080.
-        - invocationStrategy: Optionally the invocation strategy for incoming requests.
-                              If not specified, the handler for incoming requests will
-                              be invoked on DispatchQueue.global().
-        - shutdownCompletionHandlerInvocationStrategy: Optionally the invocation strategy for shutdown completion handlers.
-                                                       If not specified, the shutdown completion handlers will
-                                                       be invoked on DispatchQueue.global() synchronously so that callers
-                                                       to `waitUntilShutdown*` will not unblock until all completion handlers
-                                                       have finished.
-        - eventLoopProvider: Provides the event loop to be used by the server.
-                             If not specified, the server will create a new multi-threaded event loop
-                             with the number of threads specified by `System.coreCount`.
-        - shutdownOnSignal: Specifies if the server should be shutdown when a signal is received.
-                            If not specified, the server will be shutdown if a SIGINT is received.
-     */
-    public init(handler: HTTP1RequestHandler,
-                port: Int = ServerDefaults.defaultPort,
-                invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),
-                defaultLogger: Logger = Logger(label: "com.amazon.SmokeFramework.SmokeHTTP1.SmokeHTTP1Server"),
-                shutdownCompletionHandlerInvocationStrategy: InvocationStrategy = GlobalDispatchQueueSyncInvocationStrategy(),
-                eventLoopProvider: EventLoopProvider = .spawnNewThreads, shutdownOnSignal: ShutdownOnSignal = .sigint) {
-        let signalQueue = DispatchQueue(label: "io.smokeframework.SmokeHTTP1Server.SignalHandlingQueue")
-        
-        self.port = port
-        self.handler = handler
-        self.defaultLogger = defaultLogger
-        self.invocationStrategy = invocationStrategy
-        self.shutdownCompletionHandlerInvocationStrategy = shutdownCompletionHandlerInvocationStrategy
-        
-        switch eventLoopProvider {
-        case .spawnNewThreads:
-            self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-            self.ownEventLoopGroup = true
-        case .use(let existingEventLoopGroup):
-            self.eventLoopGroup = existingEventLoopGroup
-            self.ownEventLoopGroup = false
-        }
-        
-        let newSignalSource: (DispatchSourceSignal, Int32)?
-        switch shutdownOnSignal {
-        case .none:
-           newSignalSource = nil
-        case .sigint:
-            newSignalSource = (DispatchSource.makeSignalSource(signal: SIGINT, queue: signalQueue), SIGINT)
-        case .sigterm:
-            newSignalSource = (DispatchSource.makeSignalSource(signal: SIGTERM, queue: signalQueue), SIGTERM)
-        }
-        
-        self.quiesce = ServerQuiescingHelper(group: eventLoopGroup)
-        self.fullyShutdownPromise = eventLoopGroup.next().makePromise()
-        self.signalSource = newSignalSource?.0
-        self.shutdownDispatchGroup = DispatchGroup()
-        // enter the DispatchGroup during initialization so waiting for the
-        // shutdown of an initalized or started server will wait
-        shutdownDispatchGroup.enter()
-        
-        if let (newSignalSource, signalValue) = newSignalSource {
-            newSignalSource.setEventHandler { [unowned self] in
-                self.signalSource?.cancel()
-                defaultLogger.error("Received signal, initiating shutdown which should complete after the last request finished.")
-
-                do {
-                    try self.shutdown()
-                } catch {
-                    defaultLogger.error("Unable to shutdown server on signalSource: \(error)")
-                }
-            }
-            signal(signalValue, SIG_IGN)
-            newSignalSource.resume()
-        }
-    }
+public protocol SmokeHTTP1Server {
     
     /**
      Starts the server on the provided port. Function returns
      when the server is started. The server will continue running until
      either shutdown() is called or the surrounding application is being terminated.
      */
-    public func start() throws {
-        defaultLogger.info("SmokeHTTP1Server starting on port \(port).")
-        
-        guard updateOnStart() else {
-            // nothing to do; already started
-            return
-        }
-        
-        let currentHandler = handler
-        let currentInvocationStrategy = invocationStrategy
-        
-        // create a ServerBootstrap with a HTTP Server pipeline that delegates
-        // to a HTTPChannelInboundHandler
-        let bootstrap = ServerBootstrap(group: eventLoopGroup)
-            .serverChannelOption(ChannelOptions.backlog, value: 256)
-            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .serverChannelInitializer { [unowned self] channel in
-                channel.pipeline.addHandler(self.quiesce.makeServerChannelHandler(channel: channel))
-            }
-            .childChannelInitializer { channel in
-                channel.pipeline.configureHTTPServerPipeline().flatMap {
-                    channel.pipeline.addHandler(HTTP1ChannelInboundHandler(
-                        handler: currentHandler,
-                        invocationStrategy: currentInvocationStrategy))
-                }
-            }
-            .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
-            .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
-            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
-        
-        channel = try bootstrap.bind(host: ServerDefaults.defaultHost, port: port).wait()
-        
-        fullyShutdownPromise.futureResult.whenComplete { [unowned self] _ in
-            do {
-                let shutdownCompletionHandlers = self.updateStateOnShutdownComplete()
-                
-                // execute all the completion handlers
-                shutdownCompletionHandlers.forEach { self.shutdownCompletionHandlerInvocationStrategy.invoke(handler: $0) }
-                
-                if self.ownEventLoopGroup {
-                    try self.eventLoopGroup.syncShutdownGracefully()
-                }
-                
-                // release any waiters for shutdown
-                self.shutdownDispatchGroup.leave()
-            } catch {
-                self.defaultLogger.error("Server unable to shutdown cleanly following full shutdown.")
-            }
-            
-            self.defaultLogger.info("SmokeHTTP1Server shutdown.")
-        }
-        
-        defaultLogger.info("SmokeHTTP1Server started on port \(port).")
-    }
+    func start() throws
     
     /**
      Initiates the process of shutting down the server.
      */
-    public func shutdown() throws {
-        let doShutdownServer = try updateOnShutdownStart()
-        
-        if doShutdownServer {
-            quiesce.initiateShutdown(promise: fullyShutdownPromise)
-        }
-    }
+    func shutdown() throws
     
     /**
      Blocks until the server has been shutdown and all completion handlers
      have been executed.
      */
-    public func waitUntilShutdown() throws {
-        if !isShutdown() {
-            shutdownDispatchGroup.wait()
-        }
-    }
+    func waitUntilShutdown() throws
     
     /**
      Blocks until the server has been shutdown and all completion handlers
@@ -255,16 +80,7 @@ public class SmokeHTTP1Server {
         - onShutdown: the closure to be executed after the server has been
                       fully shutdown.
      */
-    public func waitUntilShutdownAndThen(onShutdown: @escaping () -> Void) throws {
-        let handlerQueuedForFutureShutdownComplete = addShutdownHandler(onShutdown: onShutdown)
-        
-        if handlerQueuedForFutureShutdownComplete {
-            shutdownDispatchGroup.wait()
-        } else {
-            // the server is already shutdown, immediately call the handler
-            shutdownCompletionHandlerInvocationStrategy.invoke(handler: onShutdown)
-        }
-    }
+    func waitUntilShutdownAndThen(onShutdown: @escaping () -> Void) throws
     
     /**
      Provides a closure to be executed after the server has been fully shutdown.
@@ -273,128 +89,5 @@ public class SmokeHTTP1Server {
         - onShutdown: the closure to be executed after the server has been
                       fully shutdown.
      */
-    public func onShutdown(onShutdown: @escaping () -> Void) throws {
-        let handlerQueuedForFutureShutdownComplete = addShutdownHandler(onShutdown: onShutdown)
-        
-        if !handlerQueuedForFutureShutdownComplete {
-            // the server is already shutdown, immediately call the handler
-            shutdownCompletionHandlerInvocationStrategy.invoke(handler: onShutdown)
-        }
-    }
-    
-    /**
-     Updates the Lifecycle state on a start request.
-
-     - Returns: if the start request should be acted upon (and the server started).
-                Will be false if the server is already running, shutting down or has completed shutting down.
-     */
-    private func updateOnStart() -> Bool {
-        stateLock.lock()
-        defer {
-            stateLock.unlock()
-        }
-        
-        if case .initialized = serverState {
-            serverState = .running
-            
-            return true
-        }
-        
-        return false
-    }
-    
-    /**
-     Updates the Lifecycle state on a shutdown request.
-
-     - Returns: if the shutdown request should be acted upon (and the server shutdown).
-                Will be false if the server is already shutting down or has completed shutting down.
-     - Throws: if the server has never been started.
-     */
-    private func updateOnShutdownStart() throws -> Bool {
-        stateLock.lock()
-        defer {
-            stateLock.unlock()
-        }
-        
-        let doShutdownServer: Bool
-        switch serverState {
-        case .initialized:
-            throw SmokeHTTP1ServerError.shutdownAttemptOnUnstartedServer
-        case .running:
-            serverState = .shuttingDown
-            
-            doShutdownServer = true
-        case .shuttingDown, .shutDown:
-            // nothing to do; already shutting down or shutdown
-            doShutdownServer = false
-        }
-        
-        return doShutdownServer
-    }
-    
-    /**
-     Updates the Lifecycle state on shutdown completion.
-
-     - Returns: the list of completion handlers to execute.
-     */
-    private func updateStateOnShutdownComplete() -> [() -> Void] {
-        stateLock.lock()
-        defer {
-            stateLock.unlock()
-        }
-        
-        guard case .shuttingDown = serverState else {
-            fatalError("SmokeHTTP1ServerError shutdown completed when in expected state: \(serverState)")
-        }
-        
-        let completionHandlers = shutdownCompletionHandlers
-        shutdownCompletionHandlers = []
-        serverState = .shutDown
-        
-        return completionHandlers
-    }
-    
-    /**
-     Adds a shutdown completion handler to be executed when server shutdown is complete.
-
-     - Returns: if the handler has been queued for execution when server shutdown is
-                complete in the future. Will be false if the server is already shutdown; in
-                this case, the handler can be immediately executed.
-     */
-    private func addShutdownHandler(onShutdown: @escaping () -> Void) -> Bool {
-        stateLock.lock()
-        defer {
-            stateLock.unlock()
-        }
-        
-        let handlerQueuedForFutureShutdownComplete: Bool
-        switch serverState {
-        case .initialized, .running, .shuttingDown:
-            shutdownCompletionHandlers.append(onShutdown)
-            handlerQueuedForFutureShutdownComplete = true
-        case .shutDown:
-            // already shutdown; immediately call the handler
-            handlerQueuedForFutureShutdownComplete = false
-        }
-        
-        return handlerQueuedForFutureShutdownComplete
-    }
-    
-    /**
-     Indicates if the server is currently shutdown.
-
-     - Returns: if the server is currently shutdown.
-     */
-    private func isShutdown() -> Bool {
-        stateLock.lock()
-        defer {
-            stateLock.unlock()
-        }
-        
-        if case .shutDown = serverState {
-            return true
-        }
-        
-        return false
-    }
+    func onShutdown(onShutdown: @escaping () -> Void) throws
 }

--- a/Sources/SmokeHTTP1/StandardHTTP1ResponseHandler.swift
+++ b/Sources/SmokeHTTP1/StandardHTTP1ResponseHandler.swift
@@ -19,19 +19,17 @@ import Foundation
 import NIO
 import NIOHTTP1
 import Logging
-import SmokeOperations
 
 /**
- Standard implementation of the HttpResponseHandler protocol to
- send the response to a HTTP request.
+ Handles the response to a HTTP request.
 */
-struct StandardHTTP1ResponseHandler: HTTP1ResponseHandler {
+public struct StandardHTTP1ResponseHandler<InvocationContext: HTTP1RequestInvocationContext>: HTTP1ResponseHandler {
     let requestHead: HTTPRequestHead
     let keepAliveStatus: KeepAliveStatus
     let context: ChannelHandlerContext
     let wrapOutboundOut: (_ value: HTTPServerResponsePart) -> NIOAny
     
-    func executeInEventLoop(invocationContext: SmokeServerInvocationContext, execute: @escaping () -> ()) {
+    public func executeInEventLoop(invocationContext: InvocationContext, execute: @escaping () -> ()) {
         // if we are currently on a thread that can complete the response
         if context.eventLoop.inEventLoop {
             execute()
@@ -43,35 +41,35 @@ struct StandardHTTP1ResponseHandler: HTTP1ResponseHandler {
         }
     }
     
-    func complete(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
-                  responseComponents: HTTP1ServerResponseComponents) {
+    public func complete(invocationContext: InvocationContext, status: HTTPResponseStatus,
+                         responseComponents: HTTP1ServerResponseComponents) {
         let bodySize = handleComplete(invocationContext: invocationContext, status: status, responseComponents: responseComponents)
         
-        invocationContext.invocationReporting.logger.info("Http response send: status '\(status.code)', body size '\(bodySize)'")
+        invocationContext.logger.info("Http response send: status '\(status.code)', body size '\(bodySize)'")
     }
     
-    func completeInEventLoop(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
-                             responseComponents: HTTP1ServerResponseComponents) {
+    public func completeInEventLoop(invocationContext: InvocationContext, status: HTTPResponseStatus,
+                                    responseComponents: HTTP1ServerResponseComponents) {
         executeInEventLoop(invocationContext: invocationContext) {
             self.complete(invocationContext: invocationContext, status: status, responseComponents: responseComponents)
         }
     }
     
-    func completeSilently(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
-                          responseComponents: HTTP1ServerResponseComponents) {
+    public func completeSilently(invocationContext: InvocationContext, status: HTTPResponseStatus,
+                                 responseComponents: HTTP1ServerResponseComponents) {
         let bodySize = handleComplete(invocationContext: invocationContext, status: status, responseComponents: responseComponents)
         
-        invocationContext.invocationReporting.logger.debug("Http response send: status '\(status.code)', body size '\(bodySize)'")
+        invocationContext.logger.debug("Http response send: status '\(status.code)', body size '\(bodySize)'")
     }
     
-    func completeSilentlyInEventLoop(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
-                                     responseComponents: HTTP1ServerResponseComponents) {
+    public func completeSilentlyInEventLoop(invocationContext: InvocationContext, status: HTTPResponseStatus,
+                                            responseComponents: HTTP1ServerResponseComponents) {
         executeInEventLoop(invocationContext: invocationContext) {
             self.completeSilently(invocationContext: invocationContext, status: status, responseComponents: responseComponents)
         }
     }
     
-    private func handleComplete(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
+    private func handleComplete(invocationContext: InvocationContext, status: HTTPResponseStatus,
                                 responseComponents: HTTP1ServerResponseComponents) -> Int {
         var headers = HTTPHeaders()
         
@@ -102,6 +100,9 @@ struct StandardHTTP1ResponseHandler: HTTP1ResponseHandler {
         responseComponents.additionalHeaders.forEach { header in
             headers.add(name: header.0, value: header.1)
         }
+        
+        invocationContext.decorateResponseHeaders(httpHeaders: &headers)
+        
         context.write(self.wrapOutboundOut(.head(HTTPResponseHead(version: requestHead.version,
                                                                   status: status,
                                                                   headers: headers))), promise: nil)

--- a/Sources/SmokeHTTP1/StandardSmokeHTTP1Server.swift
+++ b/Sources/SmokeHTTP1/StandardSmokeHTTP1Server.swift
@@ -1,0 +1,379 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// StandardSmokeHTTP1Server.swift
+// SmokeHTTP1
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOExtras
+import Logging
+import SmokeInvocation
+
+public struct ServerDefaults {
+    static let defaultHost = "0.0.0.0"
+    public static let defaultPort = 8080
+}
+
+public enum SmokeHTTP1ServerError: Error {
+    case shutdownAttemptOnUnstartedServer
+}
+
+/**
+ A basic non-blocking HTTP server that handles a request with an
+ optional body and returns a response with an optional body.
+ */
+public class StandardSmokeHTTP1Server<HTTP1RequestHandlerType: HTTP1RequestHandler,
+                                      InvocationContext: HTTP1RequestInvocationContext>: SmokeHTTP1Server
+        where HTTP1RequestHandlerType.ResponseHandlerType == StandardHTTP1ResponseHandler<InvocationContext> {
+    let port: Int
+    
+    let quiesce: ServerQuiescingHelper
+    let signalSource: DispatchSourceSignal?
+    let fullyShutdownPromise: EventLoopPromise<Void>
+    let handler: HTTP1RequestHandlerType
+    let invocationStrategy: InvocationStrategy
+    var channel: Channel?
+    let defaultLogger: Logger
+    let shutdownDispatchGroup: DispatchGroup
+    let shutdownCompletionHandlerInvocationStrategy: InvocationStrategy
+    
+    enum State {
+        case initialized
+        case running
+        case shuttingDown
+        case shutDown
+    }
+    private var shutdownCompletionHandlers: [() -> Void] = []
+    private var serverState: State = .initialized
+    private var stateLock: NSLock = NSLock()
+    
+    let eventLoopGroup: EventLoopGroup
+    let ownEventLoopGroup: Bool
+    
+    /**
+     Initializer.
+ 
+     - Parameters:
+        - handler: the HTTPRequestHandler to handle incoming requests.
+        - port: Optionally the localhost port for the server to listen on.
+                If not specified, defaults to 8080.
+        - invocationStrategy: Optionally the invocation strategy for incoming requests.
+                              If not specified, the handler for incoming requests will
+                              be invoked on DispatchQueue.global().
+        - shutdownCompletionHandlerInvocationStrategy: Optionally the invocation strategy for shutdown completion handlers.
+                                                       If not specified, the shutdown completion handlers will
+                                                       be invoked on DispatchQueue.global() synchronously so that callers
+                                                       to `waitUntilShutdown*` will not unblock until all completion handlers
+                                                       have finished.
+        - eventLoopProvider: Provides the event loop to be used by the server.
+                             If not specified, the server will create a new multi-threaded event loop
+                             with the number of threads specified by `System.coreCount`.
+        - shutdownOnSignal: Specifies if the server should be shutdown when a signal is received.
+                            If not specified, the server will be shutdown if a SIGINT is received.
+     */
+    public init(handler: HTTP1RequestHandlerType,
+                port: Int = ServerDefaults.defaultPort,
+                invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),
+                defaultLogger: Logger = Logger(label: "com.amazon.SmokeFramework.SmokeHTTP1.SmokeHTTP1Server"),
+                shutdownCompletionHandlerInvocationStrategy: InvocationStrategy = GlobalDispatchQueueSyncInvocationStrategy(),
+                eventLoopProvider: SmokeServerEventLoopProvider = .spawnNewThreads, shutdownOnSignal: SmokeServerShutdownOnSignal = .sigint) {
+        let signalQueue = DispatchQueue(label: "io.smokeframework.SmokeHTTP1Server.SignalHandlingQueue")
+        
+        self.port = port
+        self.handler = handler
+        self.defaultLogger = defaultLogger
+        self.invocationStrategy = invocationStrategy
+        self.shutdownCompletionHandlerInvocationStrategy = shutdownCompletionHandlerInvocationStrategy
+        
+        switch eventLoopProvider {
+        case .spawnNewThreads:
+            self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            self.ownEventLoopGroup = true
+        case .use(let existingEventLoopGroup):
+            self.eventLoopGroup = existingEventLoopGroup
+            self.ownEventLoopGroup = false
+        }
+        
+        let newSignalSource: (DispatchSourceSignal, Int32)?
+        switch shutdownOnSignal {
+        case .none:
+           newSignalSource = nil
+        case .sigint:
+            newSignalSource = (DispatchSource.makeSignalSource(signal: SIGINT, queue: signalQueue), SIGINT)
+        case .sigterm:
+            newSignalSource = (DispatchSource.makeSignalSource(signal: SIGTERM, queue: signalQueue), SIGTERM)
+        }
+        
+        self.quiesce = ServerQuiescingHelper(group: eventLoopGroup)
+        self.fullyShutdownPromise = eventLoopGroup.next().makePromise()
+        self.signalSource = newSignalSource?.0
+        self.shutdownDispatchGroup = DispatchGroup()
+        // enter the DispatchGroup during initialization so waiting for the
+        // shutdown of an initalized or started server will wait
+        shutdownDispatchGroup.enter()
+        
+        if let (newSignalSource, signalValue) = newSignalSource {
+            newSignalSource.setEventHandler { [unowned self] in
+                self.signalSource?.cancel()
+                defaultLogger.error("Received signal, initiating shutdown which should complete after the last request finished.")
+
+                do {
+                    try self.shutdown()
+                } catch {
+                    defaultLogger.error("Unable to shutdown server on signalSource: \(error)")
+                }
+            }
+            signal(signalValue, SIG_IGN)
+            newSignalSource.resume()
+        }
+    }
+    
+    /**
+     Starts the server on the provided port. Function returns
+     when the server is started. The server will continue running until
+     either shutdown() is called or the surrounding application is being terminated.
+     */
+    public func start() throws {
+        defaultLogger.info("SmokeHTTP1Server starting on port \(port).")
+        
+        guard updateOnStart() else {
+            // nothing to do; already started
+            return
+        }
+        
+        let currentHandler = handler
+        let currentInvocationStrategy = invocationStrategy
+        
+        // create a ServerBootstrap with a HTTP Server pipeline that delegates
+        // to a HTTPChannelInboundHandler
+        let bootstrap = ServerBootstrap(group: eventLoopGroup)
+            .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+            .serverChannelInitializer { [unowned self] channel in
+                channel.pipeline.addHandler(self.quiesce.makeServerChannelHandler(channel: channel))
+            }
+            .childChannelInitializer { channel in
+                channel.pipeline.configureHTTPServerPipeline().flatMap {
+                    channel.pipeline.addHandler(HTTP1ChannelInboundHandler<HTTP1RequestHandlerType,
+                                                    HTTP1RequestHandlerType.ResponseHandlerType.InvocationContext>(
+                        handler: currentHandler,
+                        invocationStrategy: currentInvocationStrategy))
+                }
+            }
+            .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+            .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+            .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+        
+        channel = try bootstrap.bind(host: ServerDefaults.defaultHost, port: port).wait()
+        
+        fullyShutdownPromise.futureResult.whenComplete { [unowned self] _ in
+            do {
+                let shutdownCompletionHandlers = self.updateStateOnShutdownComplete()
+                
+                // execute all the completion handlers
+                shutdownCompletionHandlers.forEach { self.shutdownCompletionHandlerInvocationStrategy.invoke(handler: $0) }
+                
+                if self.ownEventLoopGroup {
+                    try self.eventLoopGroup.syncShutdownGracefully()
+                }
+                
+                // release any waiters for shutdown
+                self.shutdownDispatchGroup.leave()
+            } catch {
+                self.defaultLogger.error("Server unable to shutdown cleanly following full shutdown.")
+            }
+            
+            self.defaultLogger.info("SmokeHTTP1Server shutdown.")
+        }
+        
+        defaultLogger.info("SmokeHTTP1Server started on port \(port).")
+    }
+    
+    /**
+     Initiates the process of shutting down the server.
+     */
+    public func shutdown() throws {
+        let doShutdownServer = try updateOnShutdownStart()
+        
+        if doShutdownServer {
+            quiesce.initiateShutdown(promise: fullyShutdownPromise)
+        }
+    }
+    
+    /**
+     Blocks until the server has been shutdown and all completion handlers
+     have been executed.
+     */
+    public func waitUntilShutdown() throws {
+        if !isShutdown() {
+            shutdownDispatchGroup.wait()
+        }
+    }
+    
+    /**
+     Blocks until the server has been shutdown and all completion handlers
+     have been executed. The provided closure will be added to the list of
+     completion handlers to be executed on shutdown. If the server is already
+     shutdown, the provided closure will be immediately executed.
+     
+     - Parameters:
+        - onShutdown: the closure to be executed after the server has been
+                      fully shutdown.
+     */
+    public func waitUntilShutdownAndThen(onShutdown: @escaping () -> Void) throws {
+        let handlerQueuedForFutureShutdownComplete = addShutdownHandler(onShutdown: onShutdown)
+        
+        if handlerQueuedForFutureShutdownComplete {
+            shutdownDispatchGroup.wait()
+        } else {
+            // the server is already shutdown, immediately call the handler
+            shutdownCompletionHandlerInvocationStrategy.invoke(handler: onShutdown)
+        }
+    }
+    
+    /**
+     Provides a closure to be executed after the server has been fully shutdown.
+     
+     - Parameters:
+        - onShutdown: the closure to be executed after the server has been
+                      fully shutdown.
+     */
+    public func onShutdown(onShutdown: @escaping () -> Void) throws {
+        let handlerQueuedForFutureShutdownComplete = addShutdownHandler(onShutdown: onShutdown)
+        
+        if !handlerQueuedForFutureShutdownComplete {
+            // the server is already shutdown, immediately call the handler
+            shutdownCompletionHandlerInvocationStrategy.invoke(handler: onShutdown)
+        }
+    }
+    
+    /**
+     Updates the Lifecycle state on a start request.
+
+     - Returns: if the start request should be acted upon (and the server started).
+                Will be false if the server is already running, shutting down or has completed shutting down.
+     */
+    private func updateOnStart() -> Bool {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        if case .initialized = serverState {
+            serverState = .running
+            
+            return true
+        }
+        
+        return false
+    }
+    
+    /**
+     Updates the Lifecycle state on a shutdown request.
+
+     - Returns: if the shutdown request should be acted upon (and the server shutdown).
+                Will be false if the server is already shutting down or has completed shutting down.
+     - Throws: if the server has never been started.
+     */
+    private func updateOnShutdownStart() throws -> Bool {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        let doShutdownServer: Bool
+        switch serverState {
+        case .initialized:
+            throw SmokeHTTP1ServerError.shutdownAttemptOnUnstartedServer
+        case .running:
+            serverState = .shuttingDown
+            
+            doShutdownServer = true
+        case .shuttingDown, .shutDown:
+            // nothing to do; already shutting down or shutdown
+            doShutdownServer = false
+        }
+        
+        return doShutdownServer
+    }
+    
+    /**
+     Updates the Lifecycle state on shutdown completion.
+
+     - Returns: the list of completion handlers to execute.
+     */
+    private func updateStateOnShutdownComplete() -> [() -> Void] {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        guard case .shuttingDown = serverState else {
+            fatalError("SmokeHTTP1ServerError shutdown completed when in expected state: \(serverState)")
+        }
+        
+        let completionHandlers = shutdownCompletionHandlers
+        shutdownCompletionHandlers = []
+        serverState = .shutDown
+        
+        return completionHandlers
+    }
+    
+    /**
+     Adds a shutdown completion handler to be executed when server shutdown is complete.
+
+     - Returns: if the handler has been queued for execution when server shutdown is
+                complete in the future. Will be false if the server is already shutdown; in
+                this case, the handler can be immediately executed.
+     */
+    private func addShutdownHandler(onShutdown: @escaping () -> Void) -> Bool {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        let handlerQueuedForFutureShutdownComplete: Bool
+        switch serverState {
+        case .initialized, .running, .shuttingDown:
+            shutdownCompletionHandlers.append(onShutdown)
+            handlerQueuedForFutureShutdownComplete = true
+        case .shutDown:
+            // already shutdown; immediately call the handler
+            handlerQueuedForFutureShutdownComplete = false
+        }
+        
+        return handlerQueuedForFutureShutdownComplete
+    }
+    
+    /**
+     Indicates if the server is currently shutdown.
+
+     - Returns: if the server is currently shutdown.
+     */
+    private func isShutdown() -> Bool {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        if case .shutDown = serverState {
+            return true
+        }
+        
+        return false
+    }
+}

--- a/Sources/SmokeInvocation/GlobalDispatchQueueAsyncInvocationStrategy.swift
+++ b/Sources/SmokeInvocation/GlobalDispatchQueueAsyncInvocationStrategy.swift
@@ -11,23 +11,26 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  SmokeServerInvocationReporting.swift
-//  SmokeOperations
+//  GlobalDispatchQueueAsyncInvocationStrategy.swift
+//  SmokeInvocation
 //
+
 import Foundation
-import Logging
 
 /**
- A context related to reporting on the invocation of the SmokeFramework.
+ An InvocationStrategy that will invocate the handler on
+ DispatchQueue.global(), not waiting for it to complete.
  */
-public struct SmokeServerInvocationReporting<TraceContextType: OperationTraceContext> {
-    public let logger: Logger
-    public let internalRequestId: String
-    public let traceContext: TraceContextType
+public struct GlobalDispatchQueueAsyncInvocationStrategy: InvocationStrategy {
+    let queue = DispatchQueue.global()
     
-    public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType) {
-        self.logger = logger
-        self.internalRequestId = internalRequestId
-        self.traceContext = traceContext
+    public init() {
+        
+    }
+    
+    public func invoke(handler: @escaping () -> ()) {
+        queue.async {
+            handler()
+        }
     }
 }

--- a/Sources/SmokeInvocation/GlobalDispatchQueueSyncInvocationStrategy.swift
+++ b/Sources/SmokeInvocation/GlobalDispatchQueueSyncInvocationStrategy.swift
@@ -11,23 +11,26 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  SmokeServerInvocationReporting.swift
-//  SmokeOperations
+//  GlobalDispatchQueueAsyncInvocationStrategy.swift
+//  SmokeInvocation
 //
+
 import Foundation
-import Logging
 
 /**
- A context related to reporting on the invocation of the SmokeFramework.
+ An InvocationStrategy that will invocate the handler on
+ DispatchQueue.global(), waiting for it to complete.
  */
-public struct SmokeServerInvocationReporting<TraceContextType: OperationTraceContext> {
-    public let logger: Logger
-    public let internalRequestId: String
-    public let traceContext: TraceContextType
+public struct GlobalDispatchQueueSyncInvocationStrategy: InvocationStrategy {
+    let queue = DispatchQueue.global()
     
-    public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType) {
-        self.logger = logger
-        self.internalRequestId = internalRequestId
-        self.traceContext = traceContext
+    public init() {
+        
+    }
+    
+    public func invoke(handler: @escaping () -> ()) {
+        queue.sync {
+            handler()
+        }
     }
 }

--- a/Sources/SmokeInvocation/InvocationStrategy.swift
+++ b/Sources/SmokeInvocation/InvocationStrategy.swift
@@ -11,23 +11,22 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  SmokeServerInvocationReporting.swift
-//  SmokeOperations
+//  InvocationStrategy.swift
+//  SmokeInvocation
 //
+
 import Foundation
-import Logging
 
 /**
- A context related to reporting on the invocation of the SmokeFramework.
+ A strategy protocol that manages how to invocate a handler.
  */
-public struct SmokeServerInvocationReporting<TraceContextType: OperationTraceContext> {
-    public let logger: Logger
-    public let internalRequestId: String
-    public let traceContext: TraceContextType
+public protocol InvocationStrategy {
     
-    public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType) {
-        self.logger = logger
-        self.internalRequestId = internalRequestId
-        self.traceContext = traceContext
-    }
+    /**
+     Function to handle the invocation of the handler.
+ 
+     - Parameters:
+        - handler: The handler to invocate.
+     */
+    func invoke(handler: @escaping () -> ())
 }

--- a/Sources/SmokeOperations/OperationDelegate.swift
+++ b/Sources/SmokeOperations/OperationDelegate.swift
@@ -25,6 +25,8 @@ import Logging
 public protocol OperationDelegate {
     /// The type of the request head used with this delegate.
     associatedtype RequestHeadType
+    /// The trace context type used with this delegate
+    associatedtype TraceContextType: OperationTraceContext
     /// The type of response handler used with this delegate.
     associatedtype ResponseHandlerType
     
@@ -41,7 +43,7 @@ public protocol OperationDelegate {
         - invocationContext: the context for the current invocation.
      */
     func handleResponseForOperationWithNoOutput(requestHead: RequestHeadType, responseHandler: ResponseHandlerType,
-                                                invocationContext: SmokeServerInvocationContext)
+                                                invocationContext: SmokeServerInvocationContext<TraceContextType>)
     
     /**
      Function to handle an operation failure.
@@ -54,7 +56,7 @@ public protocol OperationDelegate {
         - invocationContext: the context for the current invocation.
      */
     func handleResponseForOperationFailure(requestHead: RequestHeadType, operationFailure: OperationFailure,
-                                           responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext)
+                                           responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>)
     
     /**
      Function to handle an internal server error.
@@ -66,7 +68,7 @@ public protocol OperationDelegate {
         - invocationContext: the context for the current invocation.
      */
     func handleResponseForInternalServerError(requestHead: RequestHeadType, responseHandler: ResponseHandlerType,
-                                              invocationContext: SmokeServerInvocationContext)
+                                              invocationContext: SmokeServerInvocationContext<TraceContextType>)
     
     /**
      Function to handle an invalid operation being requested.
@@ -79,7 +81,7 @@ public protocol OperationDelegate {
         - invocationContext: the context for the current invocation.
      */
     func handleResponseForInvalidOperation(requestHead: RequestHeadType, message: String,
-                                           responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext)
+                                           responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>)
     
     /**
      Function to handle a decoding error.
@@ -92,7 +94,7 @@ public protocol OperationDelegate {
         - invocationContext: the context for the current invocation.
      */
     func handleResponseForDecodingError(requestHead: RequestHeadType, message: String,
-                                        responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext)
+                                        responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>)
     
     /**
      Function to handle a validation error.
@@ -105,5 +107,5 @@ public protocol OperationDelegate {
         - invocationContext: the context for the current invocation.
      */
     func handleResponseForValidationError(requestHead: RequestHeadType, message: String?,
-                                          responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext)
+                                          responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>)
 }

--- a/Sources/SmokeOperations/OperationHandler+blockingWithContextInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithContextInputNoOutput.swift
@@ -34,10 +34,11 @@ public extension OperationHandler {
     init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
             inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
-            operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+            operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -46,7 +47,7 @@ public extension OperationHandler {
          * throws an error, the responseHandler is called with that error.
          */
         let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
-            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext) in
+            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>
             do {
                 try operation(input, context, invocationContext.invocationReporting)

--- a/Sources/SmokeOperations/OperationHandler+blockingWithContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithContextInputWithOutput.swift
@@ -36,11 +36,12 @@ public extension OperationHandler {
         OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
-            operation: @escaping (InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType,
-            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext) -> Void),
+            operation: @escaping (InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> OutputType,
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext<TraceContextType>) -> Void),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -50,7 +51,7 @@ public extension OperationHandler {
          */
         let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
                                      responseHandler: OperationDelegateType.ResponseHandlerType,
-                                     invocationContext: SmokeServerInvocationContext) in
+                                     invocationContext: SmokeServerInvocationContext<TraceContextType>) in
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
             do {
                 let output = try operation(input, context, invocationContext.invocationReporting)

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputNoOutput.swift
@@ -42,6 +42,7 @@ public extension OperationHandler {
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -50,7 +51,7 @@ public extension OperationHandler {
          * throws an error, the responseHandler is called with that error.
          */
         let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
-            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext) in
+            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>
             do {
                 try operation(input, context)

--- a/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+blockingWithInputWithOutput.swift
@@ -41,10 +41,11 @@ public extension OperationHandler {
             reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping (InputType, ContextType) throws -> OutputType,
-            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext) -> Void),
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext<TraceContextType>) -> Void),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -54,7 +55,7 @@ public extension OperationHandler {
          */
         let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
                                      responseHandler: OperationDelegateType.ResponseHandlerType,
-                                     invocationContext: SmokeServerInvocationContext) in
+                                     invocationContext: SmokeServerInvocationContext<TraceContextType>) in
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
             do {
                 let output = try operation(input, context)

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithContextInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithContextInputNoOutput.swift
@@ -32,12 +32,15 @@ public extension OperationHandler {
           handling the operation.
      */
     init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
-            serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
+            serverName: String, operationIdentifer: OperationIdentifer,
+            reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
-            operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+            operation: @escaping ((InputType, ContextType,
+                       SmokeServerInvocationReporting<TraceContextType>, @escaping (Swift.Error?) -> ()) throws -> ()),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -46,7 +49,7 @@ public extension OperationHandler {
          * provides an error, the responseHandler is called with that error.
          */
         let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
-            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext) in
+            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>?
             do {
                 try operation(input, context, invocationContext.invocationReporting) { error in

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithContextInputWithOutput.swift
@@ -36,12 +36,13 @@ public extension OperationHandler {
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>,
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
-            operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping
+            operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>, @escaping
                 (Result<OutputType, Swift.Error>) -> Void) throws -> Void),
-            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext) -> Void),
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext<TraceContextType>) -> Void),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -50,7 +51,7 @@ public extension OperationHandler {
          * provides an error, the responseHandler is called with that error.
          */
         let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
-            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext) in
+            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>) in
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>?
             do {
                 try operation(input, context, invocationContext.invocationReporting) { result in

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputNoOutput.swift
@@ -42,6 +42,7 @@ public extension OperationHandler {
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -50,7 +51,7 @@ public extension OperationHandler {
          * provides an error, the responseHandler is called with that error.
          */
         let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
-            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext) in
+            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>) in
             let handlerResult: NoOutputOperationHandlerResult<ErrorType>?
             do {
                 try operation(input, context) { error in

--- a/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+nonblockingWithInputWithOutput.swift
@@ -42,10 +42,11 @@ public extension OperationHandler {
             inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
             operation: @escaping ((InputType, ContextType, @escaping
                 (Result<OutputType, Swift.Error>) -> Void) throws -> Void),
-            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext) -> Void),
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext<TraceContextType>) -> Void),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         /**
@@ -54,7 +55,7 @@ public extension OperationHandler {
          * provides an error, the responseHandler is called with that error.
          */
         let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
-            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext) in
+            responseHandler: ResponseHandlerType, invocationContext: SmokeServerInvocationContext<TraceContextType>) in
             let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>?
             do {
                 try operation(input, context) { result in

--- a/Sources/SmokeOperations/OperationHandlerExtensions.swift
+++ b/Sources/SmokeOperations/OperationHandlerExtensions.swift
@@ -87,8 +87,9 @@ public extension OperationHandler {
         operationDelegate: OperationDelegateType,
         requestHead: OperationDelegateType.RequestHeadType,
         responseHandler: OperationDelegateType.ResponseHandlerType,
-        invocationContext: SmokeServerInvocationContext)
+        invocationContext: SmokeServerInvocationContext<TraceContextType>)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             let logger = invocationContext.invocationReporting.logger
         
@@ -147,9 +148,10 @@ public extension OperationHandler {
         operationDelegate: OperationDelegateType,
         requestHead: RequestHeadType,
         responseHandler: ResponseHandlerType,
-        outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext) -> Void),
-        invocationContext: SmokeServerInvocationContext)
+        outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeServerInvocationContext<TraceContextType>) -> Void),
+        invocationContext: SmokeServerInvocationContext<TraceContextType>)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
+    TraceContextType == OperationDelegateType.TraceContextType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             let logger = invocationContext.invocationReporting.logger
         

--- a/Sources/SmokeOperations/OperationTraceContext.swift
+++ b/Sources/SmokeOperations/OperationTraceContext.swift
@@ -11,23 +11,19 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  SmokeServerInvocationReporting.swift
+//  OperationTraceContext.swift
 //  SmokeOperations
 //
-import Foundation
-import Logging
 
-/**
- A context related to reporting on the invocation of the SmokeFramework.
- */
-public struct SmokeServerInvocationReporting<TraceContextType: OperationTraceContext> {
-    public let logger: Logger
-    public let internalRequestId: String
-    public let traceContext: TraceContextType
+import Foundation
+
+public protocol OperationTraceContext {
+    associatedtype RequestHeadType
+    associatedtype ResponseHeadersType
     
-    public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType) {
-        self.logger = logger
-        self.internalRequestId = internalRequestId
-        self.traceContext = traceContext
-    }
+    init(requestHead: RequestHeadType)
+    
+    init<InputType: Validatable>(requestHead: RequestHeadType, input: InputType)
+    
+    func decorateResponseHeaders(httpHeaders: inout ResponseHeadersType)
 }

--- a/Sources/SmokeOperations/SmokeServerInvocationContext.swift
+++ b/Sources/SmokeOperations/SmokeServerInvocationContext.swift
@@ -16,11 +16,11 @@
 //
 import Foundation
 
-public struct SmokeServerInvocationContext {
-    public let invocationReporting: SmokeServerInvocationReporting
+public struct SmokeServerInvocationContext<TraceContextType: OperationTraceContext> {
+    public let invocationReporting: SmokeServerInvocationReporting<TraceContextType>
     public let requestReporting: SmokeServerOperationReporting
     
-    public init(invocationReporting: SmokeServerInvocationReporting,
+    public init(invocationReporting: SmokeServerInvocationReporting<TraceContextType>,
                 requestReporting: SmokeServerOperationReporting) {
         self.invocationReporting = invocationReporting
         self.requestReporting = requestReporting

--- a/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
+++ b/Sources/SmokeOperationsHTTP1/HTTP1OperationDelegate.swift
@@ -63,7 +63,7 @@ public protocol HTTP1OperationDelegate: OperationDelegate {
         requestHead: RequestHeadType,
         output: OutputType,
         responseHandler: ResponseHandlerType,
-        invocationContext: SmokeServerInvocationContext)
+        invocationContext: SmokeServerInvocationContext<TraceContextType>)
     
     /**
      Function to handle a successful response from an operation.
@@ -79,5 +79,5 @@ public protocol HTTP1OperationDelegate: OperationDelegate {
                                                            location: OperationOutputHTTPLocation,
                                                            output: OutputType,
                                                            responseHandler: ResponseHandlerType,
-                                                           invocationContext: SmokeServerInvocationContext)
+                                                           invocationContext: SmokeServerInvocationContext<TraceContextType>)
 }

--- a/Sources/SmokeOperationsHTTP1/HTTP1OperationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/HTTP1OperationTraceContext.swift
@@ -11,22 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  InvocationStrategy.swift
-//  SmokeOperations
+// HTTP1OperationTraceContext.swift
+// SmokeOperationsHTTP1
 //
 
 import Foundation
+import SmokeOperations
+import NIOHTTP1
 
-/**
- A strategy protocol that manages how to invocate a handler.
- */
-public protocol InvocationStrategy {
-    
-    /**
-     Function to handle the invocation of the handler.
- 
-     - Parameters:
-        - handler: The handler to invocate.
-     */
-    func invoke(handler: @escaping () -> ())
+public protocol HTTP1OperationTraceContext: OperationTraceContext
+    where RequestHeadType == HTTPRequestHead, ResponseHeadersType == HTTPHeaders {
+
 }

--- a/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
@@ -31,26 +31,26 @@ internal struct PingParameters {
  Implementation of the HttpRequestHandler protocol that handles an
  incoming Http request as an operation.
  */
-struct OperationServerHTTP1RequestHandler<ContextType, SelectorType, OperationIdentifer,
-                                          ResponseHandlerType: HTTP1ResponseHandler>: HTTP1RequestHandler
-        where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
+struct OperationServerHTTP1RequestHandler<SelectorType>: HTTP1RequestHandler
+        where SelectorType: SmokeHTTP1HandlerSelector,
         SmokeHTTP1RequestHead == SelectorType.DefaultOperationDelegateType.RequestHeadType,
         HTTPRequestHead == SelectorType.DefaultOperationDelegateType.TraceContextType.RequestHeadType,
-        ResponseHandlerType == SelectorType.DefaultOperationDelegateType.ResponseHandlerType,
-        SmokeServerInvocationContext<SelectorType.DefaultOperationDelegateType.TraceContextType> == ResponseHandlerType.InvocationContext,
-SelectorType.OperationIdentifer == OperationIdentifer {
+        SelectorType.DefaultOperationDelegateType.ResponseHandlerType: HTTP1ResponseHandler,
+        SmokeServerInvocationContext<SelectorType.DefaultOperationDelegateType.TraceContextType> == SelectorType.DefaultOperationDelegateType.ResponseHandlerType.InvocationContext {
+    typealias ResponseHandlerType = SelectorType.DefaultOperationDelegateType.ResponseHandlerType
+    
     
     typealias InvocationContext = ResponseHandlerType.InvocationContext
     typealias TraceContextType = SelectorType.DefaultOperationDelegateType.TraceContextType
         
     let handlerSelector: SelectorType
-    let context: ContextType
+    let context: SelectorType.ContextType
     let pingOperationReporting: SmokeServerOperationReporting
     let unknownOperationReporting: SmokeServerOperationReporting
     let errorDeterminingOperationReporting: SmokeServerOperationReporting
     
-    init(handlerSelector: SelectorType, context: ContextType, serverName: String,
-         reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer>) {
+    init(handlerSelector: SelectorType, context: SelectorType.ContextType, serverName: String,
+         reportingConfiguration: SmokeServerReportingConfiguration<SelectorType.OperationIdentifer>) {
         self.handlerSelector = handlerSelector
         self.context = context
         
@@ -93,8 +93,8 @@ SelectorType.OperationIdentifer == OperationIdentifer {
         let query = uriComponents.count > 1 ? String(uriComponents[1]) : ""
 
         // get the handler to use
-        let handler: OperationHandler<ContextType, SmokeHTTP1RequestHead, TraceContextType,
-                                      ResponseHandlerType, OperationIdentifer>
+        let handler: OperationHandler<SelectorType.ContextType, SmokeHTTP1RequestHead, TraceContextType,
+                                      ResponseHandlerType, SelectorType.OperationIdentifer>
         let shape: Shape
         let defaultOperationDelegate = handlerSelector.defaultOperationDelegate
         

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithContextInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithContextInputNoOutput.swift
@@ -33,7 +33,7 @@ public extension SmokeHTTP1HandlerSelector {
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation) {
         
@@ -71,11 +71,12 @@ public extension SmokeHTTP1HandlerSelector {
         OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
@@ -108,7 +109,7 @@ public extension SmokeHTTP1HandlerSelector {
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> ()),
         allowedErrors: [(ErrorType, Int)]) {
         
         let handler = OperationHandler(
@@ -137,10 +138,11 @@ public extension SmokeHTTP1HandlerSelector {
         OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> ()),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
     where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithContextInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithContextInputWithOutput.swift
@@ -34,7 +34,7 @@ public extension SmokeHTTP1HandlerSelector {
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation,
         outputLocation: OperationOutputHTTPLocation) {
@@ -51,7 +51,7 @@ public extension SmokeHTTP1HandlerSelector {
         func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
                            output: OutputType,
                            responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
-                           invocationContext: SmokeServerInvocationContext) {
+                           invocationContext: SmokeServerInvocationContext<TraceContextType>) {
             delegateToUse.handleResponseForOperation(requestHead: requestHead,
                                                      location: outputLocation,
                                                      output: output,
@@ -85,12 +85,13 @@ public extension SmokeHTTP1HandlerSelector {
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation,
         outputLocation: OperationOutputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
@@ -103,7 +104,7 @@ public extension SmokeHTTP1HandlerSelector {
             func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
                                output: OutputType,
                                responseHandler: OperationDelegateType.ResponseHandlerType,
-                               invocationContext: SmokeServerInvocationContext) {
+                               invocationContext: SmokeServerInvocationContext<TraceContextType>) {
                 operationDelegate.handleResponseForOperation(requestHead: requestHead,
                                                              location: outputLocation,
                                                              output: output,
@@ -136,7 +137,7 @@ public extension SmokeHTTP1HandlerSelector {
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)]) {
         
         let handler = OperationHandler(
@@ -166,10 +167,11 @@ public extension SmokeHTTP1HandlerSelector {
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting) throws -> OutputType),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>) throws -> OutputType),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
     where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputNoOutput.swift
@@ -77,6 +77,7 @@ public extension SmokeHTTP1HandlerSelector {
         inputLocation: OperationInputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
@@ -144,6 +145,7 @@ public extension SmokeHTTP1HandlerSelector {
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
     where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingWithInputWithOutput.swift
@@ -51,7 +51,7 @@ public extension SmokeHTTP1HandlerSelector {
         func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
                            output: OutputType,
                            responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
-                           invocationContext: SmokeServerInvocationContext) {
+                           invocationContext: SmokeServerInvocationContext<TraceContextType>) {
             delegateToUse.handleResponseForOperation(requestHead: requestHead,
                                                      location: outputLocation,
                                                      output: output,
@@ -92,6 +92,7 @@ public extension SmokeHTTP1HandlerSelector {
         outputLocation: OperationOutputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
@@ -104,7 +105,7 @@ public extension SmokeHTTP1HandlerSelector {
             func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
                                output: OutputType,
                                responseHandler: OperationDelegateType.ResponseHandlerType,
-                               invocationContext: SmokeServerInvocationContext) {
+                               invocationContext: SmokeServerInvocationContext<TraceContextType>) {
                 operationDelegate.handleResponseForOperation(requestHead: requestHead,
                                                              location: outputLocation,
                                                              output: output,
@@ -173,6 +174,7 @@ public extension SmokeHTTP1HandlerSelector {
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
     where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithContextInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithContextInputNoOutput.swift
@@ -33,12 +33,14 @@ public extension SmokeHTTP1HandlerSelector {
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType,
+                   SmokeServerInvocationReporting<TraceContextType>, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation) {
         
         func outputProvider(input: InputType, context: ContextType,
-                            invocationReporting: SmokeServerInvocationReporting, completion: @escaping (Swift.Error?) -> ()) throws {
+                            invocationReporting: SmokeServerInvocationReporting<TraceContextType>,
+                            completion: @escaping (Swift.Error?) -> ()) throws {
             try operation(input, context, invocationReporting, completion)
         }
         
@@ -73,18 +75,21 @@ public extension SmokeHTTP1HandlerSelector {
           handling the operation.
      */
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
-        OperationDelegateType: HTTP1OperationDelegate>(
+        OperationDelegateType: HTTP1OperationDelegate> (
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType,
+                   SmokeServerInvocationReporting<TraceContextType>, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func outputProvider(input: InputType, context: ContextType,
-                                invocationReporting: SmokeServerInvocationReporting, completion: @escaping (Swift.Error?) -> ()) throws {
+                                invocationReporting: SmokeServerInvocationReporting<TraceContextType>,
+                                completion: @escaping (Swift.Error?) -> ()) throws {
                 try operation(input, context, invocationReporting, completion)
             }
             
@@ -118,11 +123,13 @@ public extension SmokeHTTP1HandlerSelector {
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType,
+                   SmokeServerInvocationReporting<TraceContextType>, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)]) {
         
         func outputProvider(input: InputType, context: ContextType,
-                            invocationReporting: SmokeServerInvocationReporting, completion: @escaping (Swift.Error?) -> ()) throws {
+                            invocationReporting: SmokeServerInvocationReporting<TraceContextType>,
+                            completion: @escaping (Swift.Error?) -> ()) throws {
             try operation(input, context, invocationReporting, completion)
         }
         
@@ -152,14 +159,17 @@ public extension SmokeHTTP1HandlerSelector {
         OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Swift.Error?) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType,
+                   SmokeServerInvocationReporting<TraceContextType>, @escaping (Swift.Error?) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
     where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         func outputProvider(input: InputType, context: ContextType,
-                            invocationReporting: SmokeServerInvocationReporting, completion: @escaping (Swift.Error?) -> ()) throws {
+                            invocationReporting: SmokeServerInvocationReporting<TraceContextType>,
+                            completion: @escaping (Swift.Error?) -> ()) throws {
             try operation(input, context, invocationReporting, completion)
         }
         

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithContextInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithContextInputWithOutput.swift
@@ -34,7 +34,8 @@ public extension SmokeHTTP1HandlerSelector {
             ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>,
+                       @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation,
         outputLocation: OperationOutputHTTPLocation) {
@@ -51,7 +52,7 @@ public extension SmokeHTTP1HandlerSelector {
         func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
                            output: OutputType,
                            responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
-                           invocationContext: SmokeServerInvocationContext) {
+                           invocationContext: SmokeServerInvocationContext<TraceContextType>) {
             delegateToUse.handleResponseForOperation(requestHead: requestHead,
                                                      location: outputLocation,
                                                      output: output,
@@ -85,12 +86,14 @@ public extension SmokeHTTP1HandlerSelector {
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>,
+                       @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation,
         outputLocation: OperationOutputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
@@ -103,7 +106,7 @@ public extension SmokeHTTP1HandlerSelector {
             func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
                                output: OutputType,
                                responseHandler: OperationDelegateType.ResponseHandlerType,
-                               invocationContext: SmokeServerInvocationContext) {
+                               invocationContext: SmokeServerInvocationContext<TraceContextType>) {
                 operationDelegate.handleResponseForOperation(requestHead: requestHead,
                                                              location: outputLocation,
                                                              output: output,
@@ -135,7 +138,8 @@ public extension SmokeHTTP1HandlerSelector {
             ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>,
+                       @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)]) {
         
         let handler = OperationHandler(
@@ -164,10 +168,12 @@ public extension SmokeHTTP1HandlerSelector {
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting, @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
+        operation: @escaping ((InputType, ContextType, SmokeServerInvocationReporting<TraceContextType>,
+                       @escaping (Result<OutputType, Swift.Error>) -> ()) throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
     where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputNoOutput.swift
@@ -81,6 +81,7 @@ public extension SmokeHTTP1HandlerSelector {
         inputLocation: OperationInputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func outputProvider(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {
@@ -156,6 +157,7 @@ public extension SmokeHTTP1HandlerSelector {
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
     where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         func outputProvider(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingWithInputWithOutput.swift
@@ -51,7 +51,7 @@ public extension SmokeHTTP1HandlerSelector {
         func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
                            output: OutputType,
                            responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
-                           invocationContext: SmokeServerInvocationContext) {
+                           invocationContext: SmokeServerInvocationContext<TraceContextType>) {
             delegateToUse.handleResponseForOperation(requestHead: requestHead,
                                                      location: outputLocation,
                                                      output: output,
@@ -92,6 +92,7 @@ public extension SmokeHTTP1HandlerSelector {
         outputLocation: OperationOutputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
         DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
             
             func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
@@ -104,7 +105,7 @@ public extension SmokeHTTP1HandlerSelector {
             func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
                                output: OutputType,
                                responseHandler: OperationDelegateType.ResponseHandlerType,
-                               invocationContext: SmokeServerInvocationContext) {
+                               invocationContext: SmokeServerInvocationContext<TraceContextType>) {
                 operationDelegate.handleResponseForOperation(requestHead: requestHead,
                                                              location: outputLocation,
                                                              output: output,
@@ -171,6 +172,7 @@ public extension SmokeHTTP1HandlerSelector {
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
     where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.TraceContextType == OperationDelegateType.TraceContextType,
     DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
         
         let handler = OperationHandler(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector.swift
@@ -29,6 +29,10 @@ public protocol SmokeHTTP1HandlerSelector {
     associatedtype DefaultOperationDelegateType: HTTP1OperationDelegate
     associatedtype OperationIdentifer: OperationIdentity
     
+    typealias TraceContextType = DefaultOperationDelegateType.TraceContextType
+    typealias RequestHeadType = DefaultOperationDelegateType.RequestHeadType
+    typealias ResponseHandlerType = DefaultOperationDelegateType.ResponseHandlerType
+    
     /// Get the instance of the Default OperationDelegate type
     var defaultOperationDelegate: DefaultOperationDelegateType { get }
     
@@ -43,10 +47,7 @@ public protocol SmokeHTTP1HandlerSelector {
         - requestHead: the request head of an incoming operation.
      */
     func getHandlerForOperation(_ uri: String, httpMethod: HTTPMethod, requestLogger: Logger) throws
-        -> (OperationHandler<ContextType,
-            DefaultOperationDelegateType.RequestHeadType,
-            DefaultOperationDelegateType.ResponseHandlerType,
-            OperationIdentifer>, Shape)
+        -> (OperationHandler<ContextType, RequestHeadType, TraceContextType, ResponseHandlerType, OperationIdentifer>, Shape)
     
     /**
      Adds a handler for the specified uri and http method.
@@ -56,10 +57,8 @@ public protocol SmokeHTTP1HandlerSelector {
         - httpMethod: the http method to add the handler for.
         - handler: the handler to add.
      */
-    mutating func addHandlerForOperation(_ operationIdentifer: OperationIdentifer,
-                                         httpMethod: HTTPMethod,
-                                         handler: OperationHandler<ContextType,
-                                            DefaultOperationDelegateType.RequestHeadType,
-                                            DefaultOperationDelegateType.ResponseHandlerType,
-                                            OperationIdentifer>)
+    mutating func addHandlerForOperation(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        handler: OperationHandler<ContextType, RequestHeadType, TraceContextType, ResponseHandlerType, OperationIdentifer>)
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1OperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1OperationServer.swift
@@ -11,26 +11,12 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  GlobalDispatchQueueAsyncInvocationStrategy.swift
-//  SmokeOperations
+//  SmokeHTTP1OperationServer.swift
+//  SmokeOperationsHTTP1
 //
 
 import Foundation
 
-/**
- An InvocationStrategy that will invocate the handler on
- DispatchQueue.global(), not waiting for it to complete.
- */
-public struct GlobalDispatchQueueAsyncInvocationStrategy: InvocationStrategy {
-    let queue = DispatchQueue.global()
+public protocol SmokeHTTP1OperationServer {
     
-    public init() {
-        
-    }
-    
-    public func invoke(handler: @escaping () -> ()) {
-        queue.async {
-            handler()
-        }
-    }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1RequestHead.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1RequestHead.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  SmokeHTTP1Request.swift
+//  SmokeHTTP1RequestHead.swift
 //  SmokeOperationsHTTP1
 //
 

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -31,7 +31,7 @@ public extension SmokeHTTP1Server {
         defaultLogger: Logger = Logger(label: "com.amazon.SmokeFramework.SmokeHTTP1Server"),
         reportingConfiguration: SmokeServerReportingConfiguration<SelectorType.OperationIdentifer> = SmokeServerReportingConfiguration(),
         eventLoopProvider: SmokeServerEventLoopProvider = .spawnNewThreads,
-        shutdownOnSignal: SmokeServerShutdownOnSignal = .sigint) throws
+        shutdownOnSignal: SmokeServerShutdownOnSignal = .sigint) throws -> SmokeHTTP1Server
         where HTTPRequestHead == SelectorType.DefaultOperationDelegateType.TraceContextType.RequestHeadType,
         SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
         SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
@@ -39,15 +39,15 @@ public extension SmokeHTTP1Server {
             let handler = OperationServerHTTP1RequestHandler(
                 handlerSelector: handlerSelector,
                 context: context, serverName: serverName, reportingConfiguration: reportingConfiguration)
-                let server: StandardSmokeHTTP1Server<OperationServerHTTP1RequestHandler<SelectorType>, SmokeServerInvocationContext<SelectorType.DefaultOperationDelegateType.TraceContextType>> = StandardSmokeHTTP1Server(handler: handler,
+                let server = StandardSmokeHTTP1Server(handler: handler,
                                                   port: port,
                                                   invocationStrategy: invocationStrategy,
                                                   defaultLogger: defaultLogger,
                                                   eventLoopProvider: eventLoopProvider,
                                                   shutdownOnSignal: shutdownOnSignal)
             
-            //try server.start()
+            try server.start()
             
-            //return server
+            return server
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -21,13 +21,13 @@ import SmokeOperations
 import Logging
 import SmokeInvocation
 
-@available(swift 5.1)
-@available(OSX 10.15.0, *)
 public extension SmokeHTTP1Server {
     
     /**
      Creates and starts a SmokeHTTP1Server to handle operations using the
      provided handlerSelector. This call will return once the server has started.
+     
+     On Linux with Swift 5.1 the function returns an opaque return type.
      
      - Parameters:
          - handlerSelector: the selector that will provide an operation
@@ -45,6 +45,7 @@ public extension SmokeHTTP1Server {
                              If not specified, the server will be shutdown if a SIGINT is received.
      - Returns: the SmokeHTTP1Server that was created and started.
      */
+    #if os(Linux) && swift(>=5.1)
     static func startAsOperationServer<ContextType, SelectorType, OperationIdentifer>(
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
@@ -75,32 +76,7 @@ public extension SmokeHTTP1Server {
             
             return server
     }
-}
-
-@available(swift, obsoleted: 5.1)
-@available(OSX, obsoleted: 10.15.0)
-public extension SmokeHTTP1Server {
-    
-    /**
-     Creates and starts a SmokeHTTP1Server to handle operations using the
-     provided handlerSelector. This call will return once the server has started.
-     
-     - Parameters:
-         - handlerSelector: the selector that will provide an operation
-                            handler for a operation request
-         - context: the context to pass to operation handlers.
-         - port: Optionally the localhost port for the server to listen on.
-                 If not specified, defaults to 8080.
-         - invocationStrategy: Optionally the invocation strategy for incoming requests.
-                               If not specified, the handler for incoming requests will
-                               be invoked on DispatchQueue.global().
-         - eventLoopProvider: Provides the event loop to be used by the server.
-                              If not specified, the server will create a new multi-threaded event loop
-                              with the number of threads specified by `System.coreCount`.
-         - shutdownOnSignal: Specifies if the server should be shutdown when a signal is received.
-                             If not specified, the server will be shutdown if a SIGINT is received.
-     - Returns: the SmokeHTTP1Server that was created and started.
-     */
+    #else
     static func startAsOperationServer<ContextType, SelectorType, OperationIdentifer>(
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
@@ -131,4 +107,5 @@ public extension SmokeHTTP1Server {
             
             return server
     }
+    #endif
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -22,34 +22,32 @@ import Logging
 import SmokeInvocation
 
 public extension SmokeHTTP1Server {
-    static func startAsOperationServer<ContextType, SelectorType, OperationIdentifer>(
+    static func startAsOperationServer<SelectorType: SmokeHTTP1HandlerSelector>(
         withHandlerSelector handlerSelector: SelectorType,
-        andContext context: ContextType,
+        andContext context: SelectorType.ContextType,
         andPort port: Int = ServerDefaults.defaultPort,
         serverName: String = "Server",
         invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),
         defaultLogger: Logger = Logger(label: "com.amazon.SmokeFramework.SmokeHTTP1Server"),
-        reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer> = SmokeServerReportingConfiguration(),
+        reportingConfiguration: SmokeServerReportingConfiguration<SelectorType.OperationIdentifer> = SmokeServerReportingConfiguration(),
         eventLoopProvider: SmokeServerEventLoopProvider = .spawnNewThreads,
-        shutdownOnSignal: SmokeServerShutdownOnSignal = .sigint) throws -> SmokeHTTP1Server
-        where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
-        HTTPRequestHead == SelectorType.DefaultOperationDelegateType.TraceContextType.RequestHeadType,
+        shutdownOnSignal: SmokeServerShutdownOnSignal = .sigint) throws
+        where HTTPRequestHead == SelectorType.DefaultOperationDelegateType.TraceContextType.RequestHeadType,
         SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
         SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
-            StandardHTTP1ResponseHandler<SmokeServerInvocationContext<SelectorType.DefaultOperationDelegateType.TraceContextType>>,
-        SelectorType.OperationIdentifer == OperationIdentifer {
+            StandardHTTP1ResponseHandler<SmokeServerInvocationContext<SelectorType.DefaultOperationDelegateType.TraceContextType>> {
             let handler = OperationServerHTTP1RequestHandler(
                 handlerSelector: handlerSelector,
                 context: context, serverName: serverName, reportingConfiguration: reportingConfiguration)
-            let server = StandardSmokeHTTP1Server(handler: handler,
+                let server: StandardSmokeHTTP1Server<OperationServerHTTP1RequestHandler<SelectorType>, SmokeServerInvocationContext<SelectorType.DefaultOperationDelegateType.TraceContextType>> = StandardSmokeHTTP1Server(handler: handler,
                                                   port: port,
                                                   invocationStrategy: invocationStrategy,
                                                   defaultLogger: defaultLogger,
                                                   eventLoopProvider: eventLoopProvider,
                                                   shutdownOnSignal: shutdownOnSignal)
             
-            try server.start()
+            //try server.start()
             
-            return server
+            //return server
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -22,61 +22,6 @@ import Logging
 import SmokeInvocation
 
 public extension SmokeHTTP1Server {
-    
-    /**
-     Creates and starts a SmokeHTTP1Server to handle operations using the
-     provided handlerSelector. This call will return once the server has started.
-     
-     On Linux with Swift 5.1 the function returns an opaque return type.
-     
-     - Parameters:
-         - handlerSelector: the selector that will provide an operation
-                            handler for a operation request
-         - context: the context to pass to operation handlers.
-         - port: Optionally the localhost port for the server to listen on.
-                 If not specified, defaults to 8080.
-         - invocationStrategy: Optionally the invocation strategy for incoming requests.
-                               If not specified, the handler for incoming requests will
-                               be invoked on DispatchQueue.global().
-         - eventLoopProvider: Provides the event loop to be used by the server.
-                              If not specified, the server will create a new multi-threaded event loop
-                              with the number of threads specified by `System.coreCount`.
-         - shutdownOnSignal: Specifies if the server should be shutdown when a signal is received.
-                             If not specified, the server will be shutdown if a SIGINT is received.
-     - Returns: the SmokeHTTP1Server that was created and started.
-     */
-    #if os(Linux) && swift(>=5.1)
-    static func startAsOperationServer<ContextType, SelectorType, OperationIdentifer>(
-        withHandlerSelector handlerSelector: SelectorType,
-        andContext context: ContextType,
-        andPort port: Int = ServerDefaults.defaultPort,
-        serverName: String = "Server",
-        invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),
-        defaultLogger: Logger = Logger(label: "com.amazon.SmokeFramework.SmokeHTTP1Server"),
-        reportingConfiguration: SmokeServerReportingConfiguration<OperationIdentifer> = SmokeServerReportingConfiguration(),
-        eventLoopProvider: SmokeServerEventLoopProvider = .spawnNewThreads,
-        shutdownOnSignal: SmokeServerShutdownOnSignal = .sigint) throws -> some SmokeHTTP1Server
-        where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ContextType,
-        HTTPRequestHead == SelectorType.DefaultOperationDelegateType.TraceContextType.RequestHeadType,
-        SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
-        SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
-            StandardHTTP1ResponseHandler<SmokeServerInvocationContext<SelectorType.DefaultOperationDelegateType.TraceContextType>>,
-        SelectorType.OperationIdentifer == OperationIdentifer {
-            let handler = OperationServerHTTP1RequestHandler(
-                handlerSelector: handlerSelector,
-                context: context, serverName: serverName, reportingConfiguration: reportingConfiguration)
-            let server = StandardSmokeHTTP1Server(handler: handler,
-                                                  port: port,
-                                                  invocationStrategy: invocationStrategy,
-                                                  defaultLogger: defaultLogger,
-                                                  eventLoopProvider: eventLoopProvider,
-                                                  shutdownOnSignal: shutdownOnSignal)
-            
-            try server.start()
-            
-            return server
-    }
-    #else
     static func startAsOperationServer<ContextType, SelectorType, OperationIdentifer>(
         withHandlerSelector handlerSelector: SelectorType,
         andContext context: ContextType,
@@ -107,5 +52,4 @@ public extension SmokeHTTP1Server {
             
             return server
     }
-    #endif
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
@@ -11,23 +11,21 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  SmokeServerInvocationReporting.swift
-//  SmokeOperations
-//
-import Foundation
-import Logging
+// SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
+// SmokeOperationsHTTP1
 
-/**
- A context related to reporting on the invocation of the SmokeFramework.
- */
-public struct SmokeServerInvocationReporting<TraceContextType: OperationTraceContext> {
-    public let logger: Logger
-    public let internalRequestId: String
-    public let traceContext: TraceContextType
+import Foundation
+import SmokeHTTP1
+import SmokeOperations
+import Logging
+import NIOHTTP1
+
+extension SmokeServerInvocationContext: HTTP1RequestInvocationContext where TraceContextType.ResponseHeadersType == HTTPHeaders {
+    public var logger: Logger {
+        return self.invocationReporting.logger
+    }
     
-    public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType) {
-        self.logger = logger
-        self.internalRequestId = internalRequestId
-        self.traceContext = traceContext
+    public func decorateResponseHeaders(httpHeaders: inout HTTPHeaders) {
+        self.invocationReporting.traceContext.decorateResponseHeaders(httpHeaders: &httpHeaders)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
@@ -34,6 +34,7 @@ public struct StandardSmokeHTTP1HandlerSelector<ContextType, DefaultOperationDel
     
     public typealias SelectorOperationHandlerType = OperationHandler<ContextType,
             DefaultOperationDelegateType.RequestHeadType,
+            DefaultOperationDelegateType.TraceContextType,
             DefaultOperationDelegateType.ResponseHandlerType,
             OperationIdentifer>
     

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1AsyncTests.swift
@@ -100,9 +100,10 @@ func handleBadHTTP1OperationAsyncWithThrow(input: ExampleHTTP1Input, context: Ex
     throw MyError.theError(reason: "Is bad!")
 }
 
-fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate, TestOperations> = {
-    let defaultOperationDelegate = JSONPayloadHTTP1OperationDelegate()
-    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate, TestOperations>(
+fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext,
+        GenericJSONPayloadHTTP1OperationDelegate<TestHttpResponseHandler, TestOperationTraceContext>, TestOperations> = {
+    let defaultOperationDelegate = GenericJSONPayloadHTTP1OperationDelegate<TestHttpResponseHandler, TestOperationTraceContext>()
+    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, GenericJSONPayloadHTTP1OperationDelegate, TestOperations>(
         defaultOperationDelegate: defaultOperationDelegate)
     
     newHandlerSelector.addHandlerForOperation(

--- a/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/SmokeOperationsHTTP1SyncTests.swift
@@ -112,9 +112,11 @@ enum TestOperations: String, OperationIdentity {
     }
 }
 
-fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate, TestOperations> = {
-    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, JSONPayloadHTTP1OperationDelegate, TestOperations>(
-        defaultOperationDelegate: JSONPayloadHTTP1OperationDelegate())
+typealias TestJSONPayloadHTTP1OperationDelegate = GenericJSONPayloadHTTP1OperationDelegate<TestHttpResponseHandler, TestOperationTraceContext>
+
+fileprivate let handlerSelector: StandardSmokeHTTP1HandlerSelector<ExampleContext, TestJSONPayloadHTTP1OperationDelegate, TestOperations> = {
+    var newHandlerSelector = StandardSmokeHTTP1HandlerSelector<ExampleContext, TestJSONPayloadHTTP1OperationDelegate, TestOperations>(
+        defaultOperationDelegate: GenericJSONPayloadHTTP1OperationDelegate())
     newHandlerSelector.addHandlerForOperation(
         .exampleOperation, httpMethod: .POST,
         operation: handleExampleOperation,

--- a/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
@@ -249,7 +249,7 @@ where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == Examp
     TestOperationTraceContext == SelectorType.DefaultOperationDelegateType.TraceContextType,
     SelectorType.DefaultOperationDelegateType.ResponseHandlerType == TestHttpResponseHandler,
     SelectorType.OperationIdentifer == TestOperations {
-    let handler = OperationServerHTTP1RequestHandler<ExampleContext, SelectorType, TestOperations, SelectorType.DefaultOperationDelegateType.ResponseHandlerType>(
+    let handler = OperationServerHTTP1RequestHandler<SelectorType>(
         handlerSelector: handlerSelector,
         context: ExampleContext(), serverName: "Server", reportingConfiguration: SmokeServerReportingConfiguration<TestOperations>())
     

--- a/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
@@ -19,6 +19,7 @@ import SmokeOperations
 import NIOHTTP1
 import SmokeHTTP1
 import Logging
+import SmokeInvocation
 @testable import SmokeOperationsHTTP1
 import XCTest
 
@@ -48,26 +49,40 @@ struct OperationResponse {
     let responseComponents: HTTP1ServerResponseComponents
 }
 
+struct TestOperationTraceContext: HTTP1OperationTraceContext {
+    func decorateResponseHeaders(httpHeaders: inout HTTPHeaders) {
+        // do nothing
+    }
+    
+    init(requestHead: HTTPRequestHead) {
+        // do nothing
+    }
+    
+    init<InputType>(requestHead: HTTPRequestHead, input: InputType) where InputType : Validatable {
+        // do nothing
+    }
+}
+
 class TestHttpResponseHandler: HTTP1ResponseHandler {
     var response: OperationResponse?
     
-    func complete(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
+    func complete(invocationContext: SmokeServerInvocationContext<TestOperationTraceContext>, status: HTTPResponseStatus,
                   responseComponents: HTTP1ServerResponseComponents) {
         response = OperationResponse(status: status,
                                      responseComponents: responseComponents)
     }
     
-    func completeInEventLoop(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
+    func completeInEventLoop(invocationContext: SmokeServerInvocationContext<TestOperationTraceContext>, status: HTTPResponseStatus,
                              responseComponents: HTTP1ServerResponseComponents) {
         complete(invocationContext: invocationContext, status: status, responseComponents: responseComponents)
     }
     
-    func completeSilentlyInEventLoop(invocationContext: SmokeServerInvocationContext, status: HTTPResponseStatus,
+    func completeSilentlyInEventLoop(invocationContext: SmokeServerInvocationContext<TestOperationTraceContext>, status: HTTPResponseStatus,
                                      responseComponents: HTTP1ServerResponseComponents) {
         complete(invocationContext: invocationContext, status: status, responseComponents: responseComponents)
     }
     
-    func executeInEventLoop(invocationContext: SmokeServerInvocationContext, execute: @escaping () -> ()) {
+    func executeInEventLoop(invocationContext: SmokeServerInvocationContext<TestOperationTraceContext>, execute: @escaping () -> ()) {
         execute()
     }
 }
@@ -231,9 +246,10 @@ func verifyPathOutput<SelectorType>(uri: String, body: Data,
                                     additionalHeaders: [(String, String)] = []) -> OperationResponse
 where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ExampleContext,
     SmokeHTTP1RequestHead == SelectorType.DefaultOperationDelegateType.RequestHeadType,
-    HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType,
+    TestOperationTraceContext == SelectorType.DefaultOperationDelegateType.TraceContextType,
+    SelectorType.DefaultOperationDelegateType.ResponseHandlerType == TestHttpResponseHandler,
     SelectorType.OperationIdentifer == TestOperations {
-    let handler = OperationServerHTTP1RequestHandler<ExampleContext, SelectorType, TestOperations>(
+    let handler = OperationServerHTTP1RequestHandler<ExampleContext, SelectorType, TestOperations, SelectorType.DefaultOperationDelegateType.ResponseHandlerType>(
         handlerSelector: handlerSelector,
         context: ExampleContext(), serverName: "Server", reportingConfiguration: SmokeServerReportingConfiguration<TestOperations>())
     
@@ -259,7 +275,8 @@ func verifyErrorResponse<SelectorType>(uri: String,
                                        additionalHeaders: [(String, String)] = []) throws
 where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == ExampleContext,
     SmokeHTTP1RequestHead == SelectorType.DefaultOperationDelegateType.RequestHeadType,
-    HTTP1ResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType,
+    TestHttpResponseHandler == SelectorType.DefaultOperationDelegateType.ResponseHandlerType,
+    TestOperationTraceContext == SelectorType.DefaultOperationDelegateType.TraceContextType,
     SelectorType.OperationIdentifer == TestOperations {
     let response = verifyPathOutput(uri: uri,
                                     body: serializedAlternateInput.data(using: .utf8)!,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a `OperationTraceContext` to the `SmokeServerInvocationContext` created for each invocation. The type can be used to store trace context from the incoming request and decorate the headers of the response. The trace context can be exposed to the operation handlers so trace information can be passed to downstream clients.

I have temporarily disabled the tests in CI. This is due to https://bugs.swift.org/browse/SR-12204. I am tracking this issue with #40.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
