### PR TITLE
Per invocation context provider

### DIFF
--- a/Sources/SmokeOperations/PerInvocationContext.swift
+++ b/Sources/SmokeOperations/PerInvocationContext.swift
@@ -1,0 +1,23 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  PerInvocationContext.swift
+//  SmokeOperations
+//
+
+import Foundation
+
+public enum PerInvocationContext<ContextType, TraceContextType: OperationTraceContext> {
+    case `static`(ContextType)
+    case provider((SmokeServerInvocationReporting<TraceContextType>) -> ContextType)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add option to pass a per-invocation context provider rather than the context directly. This allows the context to be constructed per-invocation, such as creating clients from their generators or adding a per-invocation logger instance.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
