### PR TITLE
Smoke invocation trace context

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "705a512220e9308c3268e85ea4db8535b54294eb",
-          "version": "2.0.0-alpha.4"
+          "revision": "1e42bb839956c0132d82b3cda20981eb81fbb532",
+          "version": "2.0.0-alpha.5"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "3fefedaaef285830cc98ae80231140122076a7e0",
-          "version": "1.2.0"
+          "revision": "708b960b4605abb20bc55d65abf6bad607252200",
+          "version": "2.0.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "8066b0f581604e3711979307a4377457e2b0f007",
-          "version": "2.9.0"
+          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
+          "version": "2.14.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "ed97628fa310c314c4a5cd8038445054b2991f07",
-          "version": "1.3.1"
+          "revision": "b4dbfacff47fb8d0f9e0a422d8d37935a9f10570",
+          "version": "1.4.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "e5c1af45ac934ac0a6117b2927a51d845cf4f705",
-          "version": "2.4.3"
+          "revision": "af46d9b58fafbb76f9b01177568d435a1b024f99",
+          "version": "2.6.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
             targets: ["SmokeHTTP1"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
         .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha"),
@@ -54,7 +54,7 @@ let package = Package(
         .target(
             name: "SmokeOperationsHTTP1",
             dependencies: ["SmokeOperations", "SmokeHTTP1", "QueryCoding",
-                           "HTTPPathCoding", "HTTPHeadersCoding"]),
+                           "HTTPPathCoding", "HTTPHeadersCoding", "SmokeHTTPClient"]),
         .testTarget(
             name: "SmokeOperationsHTTP1Tests",
             dependencies: ["SmokeOperationsHTTP1"]),

--- a/Sources/SmokeHTTP1/HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeHTTP1/HTTP1RequestInvocationContext.swift
@@ -23,8 +23,6 @@ public protocol HTTP1RequestInvocationContext {
     
     var logger: Logger { get }
     
-    func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?)
-    
     func handleInwardsRequestComplete(httpHeaders: inout HTTPHeaders, status: HTTPResponseStatus,
                                       body: (contentType: String, data: Data)?)
 }

--- a/Sources/SmokeHTTP1/HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeHTTP1/HTTP1RequestInvocationContext.swift
@@ -23,5 +23,8 @@ public protocol HTTP1RequestInvocationContext {
     
     var logger: Logger { get }
     
-    func decorateResponseHeaders(httpHeaders: inout HTTPHeaders)
+    func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?)
+    
+    func handleInwardsRequestComplete(httpHeaders: inout HTTPHeaders, status: HTTPResponseStatus,
+                                      body: (contentType: String, data: Data)?)
 }

--- a/Sources/SmokeHTTP1/StandardHTTP1ResponseHandler.swift
+++ b/Sources/SmokeHTTP1/StandardHTTP1ResponseHandler.swift
@@ -101,7 +101,7 @@ public struct StandardHTTP1ResponseHandler<InvocationContext: HTTP1RequestInvoca
             headers.add(name: header.0, value: header.1)
         }
         
-        invocationContext.decorateResponseHeaders(httpHeaders: &headers)
+        invocationContext.handleInwardsRequestComplete(httpHeaders: &headers, status: status, body: responseComponents.body)
         
         context.write(self.wrapOutboundOut(.head(HTTPResponseHead(version: requestHead.version,
                                                                   status: status,

--- a/Sources/SmokeOperations/OperationTraceContext.swift
+++ b/Sources/SmokeOperations/OperationTraceContext.swift
@@ -25,7 +25,7 @@ public protocol OperationTraceContext {
     
     init(requestHead: RequestHeadType, bodyData: Data?)
     
-    func handleInwardsRequestStart(requestHead: RequestHeadType, bodyData: Data?, logger: Logger, internalRequestId: String)
+    func handleInwardsRequestStart(requestHead: RequestHeadType, bodyData: Data?, logger: inout Logger, internalRequestId: String)
     
     func handleInwardsRequestComplete(httpHeaders: inout ResponseHeadersType, status: ResponseStatusType, body: (contentType: String, data: Data)?,
                                       logger: Logger, internalRequestId: String)

--- a/Sources/SmokeOperations/OperationTraceContext.swift
+++ b/Sources/SmokeOperations/OperationTraceContext.swift
@@ -16,14 +16,17 @@
 //
 
 import Foundation
+import Logging
 
 public protocol OperationTraceContext {
     associatedtype RequestHeadType
     associatedtype ResponseHeadersType
+    associatedtype ResponseStatusType
     
-    init(requestHead: RequestHeadType)
+    init(requestHead: RequestHeadType, bodyData: Data?)
     
-    init<InputType: Validatable>(requestHead: RequestHeadType, input: InputType)
+    func handleInwardsRequestStart(requestHead: RequestHeadType, bodyData: Data?, logger: Logger, internalRequestId: String)
     
-    func decorateResponseHeaders(httpHeaders: inout ResponseHeadersType)
+    func handleInwardsRequestComplete(httpHeaders: inout ResponseHeadersType, status: ResponseStatusType, body: (contentType: String, data: Data)?,
+                                      logger: Logger, internalRequestId: String)
 }

--- a/Sources/SmokeOperations/SmokeServerInvocationReporting.swift
+++ b/Sources/SmokeOperations/SmokeServerInvocationReporting.swift
@@ -14,6 +14,7 @@
 //  SmokeServerInvocationReporting.swift
 //  SmokeOperations
 //
+
 import Foundation
 import Logging
 

--- a/Sources/SmokeOperationsHTTP1/HTTP1OperationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/HTTP1OperationTraceContext.swift
@@ -20,6 +20,6 @@ import SmokeOperations
 import NIOHTTP1
 
 public protocol HTTP1OperationTraceContext: OperationTraceContext
-    where RequestHeadType == HTTPRequestHead, ResponseHeadersType == HTTPHeaders {
+    where RequestHeadType == HTTPRequestHead, ResponseHeadersType == HTTPHeaders, ResponseStatusType == HTTPResponseStatus {
 
 }

--- a/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
@@ -87,7 +87,7 @@ struct OperationServerHTTP1RequestHandler<SelectorType>: HTTP1RequestHandler
             
             let traceContext = TraceContextType(requestHead: requestHead, bodyData: body)
             traceContext.handleInwardsRequestStart(requestHead: requestHead, bodyData: body,
-                                                   logger: decoratedRequestLogger, internalRequestId: internalRequestId)
+                                                   logger: &decoratedRequestLogger, internalRequestId: internalRequestId)
             let invocationReporting = SmokeServerInvocationReporting(logger: decoratedRequestLogger,
                                                                      internalRequestId: internalRequestId, traceContext: traceContext)
             return SmokeServerInvocationContext(invocationReporting: invocationReporting,
@@ -150,10 +150,12 @@ struct OperationServerHTTP1RequestHandler<SelectorType>: HTTP1RequestHandler
                                                           pathShape: shape)
         
         let traceContext = TraceContextType(requestHead: requestHead, bodyData: body)
-        traceContext.handleInwardsRequestStart(requestHead: requestHead, bodyData: body, logger: requestLogger, internalRequestId: internalRequestId)
+        var decoratedRequestLogger: Logger = requestLogger
+        traceContext.handleInwardsRequestStart(requestHead: requestHead, bodyData: body,
+                                               logger: &decoratedRequestLogger, internalRequestId: internalRequestId)
         // let it be handled
         handler.handle(smokeHTTP1RequestHead, body: body, withContext: context,
                        responseHandler: responseHandler, invocationStrategy: invocationStrategy,
-                       requestLogger: requestLogger, internalRequestId: internalRequestId, traceContext: traceContext)
+                       requestLogger: decoratedRequestLogger, internalRequestId: internalRequestId, traceContext: traceContext)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/OperationServerHTTP1RequestHandler.swift
@@ -85,7 +85,9 @@ struct OperationServerHTTP1RequestHandler<SelectorType>: HTTP1RequestHandler
             var decoratedRequestLogger: Logger = requestLogger
             handlerSelector.defaultOperationDelegate.decorateLoggerForAnonymousRequest(requestLogger: &decoratedRequestLogger)
             
-            let traceContext = TraceContextType(requestHead: requestHead)
+            let traceContext = TraceContextType(requestHead: requestHead, bodyData: body)
+            traceContext.handleInwardsRequestStart(requestHead: requestHead, bodyData: body,
+                                                   logger: decoratedRequestLogger, internalRequestId: internalRequestId)
             let invocationReporting = SmokeServerInvocationReporting(logger: decoratedRequestLogger,
                                                                      internalRequestId: internalRequestId, traceContext: traceContext)
             return SmokeServerInvocationContext(invocationReporting: invocationReporting,
@@ -147,7 +149,8 @@ struct OperationServerHTTP1RequestHandler<SelectorType>: HTTP1RequestHandler
                                                           query: query,
                                                           pathShape: shape)
         
-        let traceContext = TraceContextType(requestHead: requestHead)
+        let traceContext = TraceContextType(requestHead: requestHead, bodyData: body)
+        traceContext.handleInwardsRequestStart(requestHead: requestHead, bodyData: body, logger: requestLogger, internalRequestId: internalRequestId)
         // let it be handled
         handler.handle(smokeHTTP1RequestHead, body: body, withContext: context,
                        responseHandler: responseHandler, invocationStrategy: invocationStrategy,

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -1,0 +1,177 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  SmokeInvocationTraceContext.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+import Logging
+import SmokeHTTPClient
+import SmokeOperations
+import NIOHTTP1
+
+private extension Data {
+    var debugString: String {
+        return String(data: self, encoding: .utf8) ?? ""
+    }
+}
+
+private extension Optional where Wrapped == Data {
+    var debugString: String {
+        switch self {
+        case .some(let wrapped):
+            return wrapped.debugString
+        case .none:
+            return ""
+        }
+    }
+}
+
+private let requestIdHeader = "x-smoke-request-id"
+private let traceIdHeader = "x-smoke-trace-id"
+
+/**
+  A  type conforming to both the `HTTP1OperationTraceContext` and `InvocationTraceContext` protocols providing basic logging and tracing.
+ */
+public struct SmokeInvocationTraceContext {
+    private let externalRequestId: String?
+    private let traceId: String?
+}
+
+extension SmokeInvocationTraceContext: HTTP1OperationTraceContext {
+    
+    public init(requestHead: HTTPRequestHead, bodyData: Data?) {
+        let requestIds = requestHead.headers[requestIdHeader]
+        let traceIds = requestHead.headers[traceIdHeader]
+        
+        // get the request id if present
+        if !requestIds.isEmpty {
+            self.externalRequestId = requestIds.joined(separator: ",")
+        } else {
+            self.externalRequestId = nil
+        }
+        
+        // get the trace id if present
+        if !traceIds.isEmpty {
+            self.traceId = traceIds.joined(separator: ",")
+        } else {
+            self.traceId = nil
+        }
+    }
+    
+    public func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?, logger: Logger, internalRequestId: String) {
+        var logElements: [String] = []
+        logElements.append("Incoming \(requestHead.method) request received.")
+        
+        if let externalRequestId = self.externalRequestId {
+            logElements.append("Received \(requestIdHeader) header '\(externalRequestId)'")
+        }
+        
+        if let traceId = self.traceId {
+            logElements.append("Received \(traceIdHeader) header '\(traceId)'")
+        }
+        
+        if let bodyData = bodyData {
+            logElements.append("Received body with size \(bodyData.count): \(bodyData.debugString)")
+        }
+        
+        // log details about the incoming request
+        logger.info("\(logElements.joined(separator: " "))")
+    }
+    
+    public func handleInwardsRequestComplete(httpHeaders: inout HTTPHeaders, status: HTTPResponseStatus,
+                                             body: (contentType: String, data: Data)?, logger: Logger, internalRequestId: String) {
+        // pass the internalRequestId back to the upstream caller
+        httpHeaders.add(name: requestIdHeader, value: internalRequestId)
+        
+        // pass the trace id back to the upstream caller if present
+        if let traceId = traceId {
+            httpHeaders.add(name: traceIdHeader, value: traceId)
+        }
+        
+        var logElements: [String] = []
+        logElements.append("Incoming request responded with status \(status).")
+        
+        if let body = body {
+            logElements.append("Sent body with content type '\(body.contentType)', size \(body.data.count): \(body.data.debugString)")
+        }
+        
+        // log details about the response to the incoming request
+        let logLine = logElements.joined(separator: " ")
+        if status == .ok {
+            logger.info("\(logLine)")
+        } else {
+            logger.error("\(logLine)")
+        }
+    }
+}
+    
+extension SmokeInvocationTraceContext: InvocationTraceContext {
+    public typealias OutwardsRequestContext = String
+    
+    public func handleOutwardsRequestStart(method: HTTPMethod, uri: String, version: HTTPVersion, logger: Logger, internalRequestId: String,
+                                    headers: inout [(String, String)], bodyData: Data) -> String {
+        // log details about the outgoing request
+        logger.debug("Starting outgoing \(method) request to endpoint '\(uri)'. Received body with size \(bodyData.count): \(bodyData.debugString)")
+        
+        // pass the internal request id to the downstream caller
+        headers.append((requestIdHeader, internalRequestId))
+        
+        // pass the trace id to the downstream caller if present
+        if let traceId = traceId {
+            headers.append((traceIdHeader, traceId))
+        }
+        
+        return ""
+    }
+    
+    public func handleOutwardsRequestSuccess(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
+                                      responseHead: HTTPResponseHead?, bodyData: Data?) {
+        let logLine = getLogLine(successfullyCompletedRequest: true, responseHead: responseHead, bodyData: bodyData)
+        
+        logger.info("\(logLine)")
+    }
+    
+    public func handleOutwardsRequestFailure(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
+                                      responseHead: HTTPResponseHead?, bodyData: Data?, error: Error) {
+        let logLine = getLogLine(successfullyCompletedRequest: true, responseHead: responseHead, bodyData: bodyData)
+        
+        logger.error("\(logLine)")
+    }
+    
+    private func getLogLine(successfullyCompletedRequest: Bool, responseHead: HTTPResponseHead?, bodyData: Data?) -> String {
+        var logElements: [String] = []
+        let completionString = successfullyCompletedRequest ? "Successfully" : "Unsuccessfully"
+        logElements.append("\(completionString) completed outgoing request.")
+        
+        if let code = responseHead?.status.code {
+            logElements.append("Returned status code: \(code)")
+        }
+        
+        if let requestIds = responseHead?.headers[requestIdHeader], !requestIds.isEmpty {
+            logElements.append("Returned \(requestIdHeader) header '\(requestIds.joined(separator: ","))'")
+        }
+        
+        if let traceIds = responseHead?.headers[traceIdHeader], !traceIds.isEmpty {
+            logElements.append("Returned \(traceIdHeader) header '\(traceIds.joined(separator: ","))'")
+        }
+        
+        if let bodyData = bodyData {
+            logElements.append("Returned body with size \(bodyData.count): \(bodyData.debugString)")
+        }
+        
+        // log details about the response to the outgoing request
+        return logElements.joined(separator: " ")
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -70,16 +70,20 @@ extension SmokeInvocationTraceContext: HTTP1OperationTraceContext {
         }
     }
     
-    public func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?, logger: Logger, internalRequestId: String) {
+    public func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?, logger: inout Logger, internalRequestId: String) {
         var logElements: [String] = []
         logElements.append("Incoming \(requestHead.method) request received.")
         
         if let externalRequestId = self.externalRequestId {
             logElements.append("Received \(requestIdHeader) header '\(externalRequestId)'")
+            
+            logger[metadataKey: requestIdHeader] = "\(externalRequestId)"
         }
         
         if let traceId = self.traceId {
             logElements.append("Received \(traceIdHeader) header '\(traceId)'")
+            
+            logger[metadataKey: traceIdHeader] = "\(traceId)"
         }
         
         if let bodyData = bodyData {

--- a/Sources/SmokeOperationsHTTP1/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
@@ -28,12 +28,6 @@ extension SmokeServerInvocationContext: HTTP1RequestInvocationContext where
         return self.invocationReporting.logger
     }
     
-    public func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?) {
-        self.invocationReporting.traceContext.handleInwardsRequestStart(requestHead: requestHead, bodyData: bodyData,
-                                                                        logger: self.invocationReporting.logger,
-                                                                        internalRequestId: self.invocationReporting.internalRequestId)
-    }
-    
     public func handleInwardsRequestComplete(httpHeaders: inout HTTPHeaders, status: HTTPResponseStatus, body: (contentType: String, data: Data)?) {
         self.invocationReporting.traceContext.handleInwardsRequestComplete(httpHeaders: &httpHeaders, status: status, body: body,
                                                                            logger: self.invocationReporting.logger,

--- a/Sources/SmokeOperationsHTTP1/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
@@ -20,12 +20,23 @@ import SmokeOperations
 import Logging
 import NIOHTTP1
 
-extension SmokeServerInvocationContext: HTTP1RequestInvocationContext where TraceContextType.ResponseHeadersType == HTTPHeaders {
+extension SmokeServerInvocationContext: HTTP1RequestInvocationContext where
+        TraceContextType.RequestHeadType == HTTPRequestHead,
+        TraceContextType.ResponseHeadersType == HTTPHeaders, TraceContextType.ResponseStatusType == HTTPResponseStatus {
+    
     public var logger: Logger {
         return self.invocationReporting.logger
     }
     
-    public func decorateResponseHeaders(httpHeaders: inout HTTPHeaders) {
-        self.invocationReporting.traceContext.decorateResponseHeaders(httpHeaders: &httpHeaders)
+    public func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?) {
+        self.invocationReporting.traceContext.handleInwardsRequestStart(requestHead: requestHead, bodyData: bodyData,
+                                                                        logger: self.invocationReporting.logger,
+                                                                        internalRequestId: self.invocationReporting.internalRequestId)
+    }
+    
+    public func handleInwardsRequestComplete(httpHeaders: inout HTTPHeaders, status: HTTPResponseStatus, body: (contentType: String, data: Data)?) {
+        self.invocationReporting.traceContext.handleInwardsRequestComplete(httpHeaders: &httpHeaders, status: status, body: body,
+                                                                           logger: self.invocationReporting.logger,
+                                                                           internalRequestId: self.invocationReporting.internalRequestId)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeServerInvocationReporting+withInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeServerInvocationReporting+withInvocationTraceContext.swift
@@ -1,0 +1,48 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeServerInvocationReporting+withInvocationTraceContext.swift
+// SmokeOperationsHTTP1
+
+import Foundation
+import Logging
+import SmokeOperations
+import SmokeHTTPClient
+
+public struct DelegatedInvocationReporting<TraceContextType: InvocationTraceContext>: HTTPClientCoreInvocationReporting {
+    public let logger: Logger
+    public var internalRequestId: String
+    public var traceContext: TraceContextType
+    
+    public init(logger: Logger,
+                internalRequestId: String,
+                traceContext: TraceContextType) {
+        self.logger = logger
+        self.internalRequestId = internalRequestId
+        self.traceContext = traceContext
+    }
+}
+
+public extension SmokeServerInvocationReporting {
+    
+    /**
+     * Creates an instance conforming to the `HTTPClientCoreInvocationReporting` protocol from this instance and the provided trace context.
+     */
+    func withInvocationTraceContext<TraceContextType: InvocationTraceContext>(
+        traceContext: TraceContextType) -> DelegatedInvocationReporting<TraceContextType> {
+        return DelegatedInvocationReporting(logger: self.logger,
+                                            internalRequestId: self.internalRequestId,
+                                            traceContext: traceContext)
+        
+    }
+}

--- a/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
@@ -50,17 +50,19 @@ struct OperationResponse {
 }
 
 struct TestOperationTraceContext: HTTP1OperationTraceContext {
-    func decorateResponseHeaders(httpHeaders: inout HTTPHeaders) {
-        // do nothing
+    init(requestHead: HTTPRequestHead, bodyData: Data?) {
+        // nothing to do
     }
     
-    init(requestHead: HTTPRequestHead) {
-        // do nothing
+    func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?, logger: Logger, internalRequestId: String) {
+        // nothing to do
     }
     
-    init<InputType>(requestHead: HTTPRequestHead, input: InputType) where InputType : Validatable {
-        // do nothing
+    func handleInwardsRequestComplete(httpHeaders: inout HTTPHeaders, status: HTTPResponseStatus,
+                                      body: (contentType: String, data: Data)?, logger: Logger, internalRequestId: String) {
+        // nothing to do
     }
+    
 }
 
 class TestHttpResponseHandler: HTTP1ResponseHandler {

--- a/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
@@ -54,7 +54,7 @@ struct TestOperationTraceContext: HTTP1OperationTraceContext {
         // nothing to do
     }
     
-    func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?, logger: Logger, internalRequestId: String) {
+    func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?, logger: inout Logger, internalRequestId: String) {
         // nothing to do
     }
     


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add a SmokeInvocationTraceContext type for basic logging and tracing.
2. Update the related protocols to to pass the request logger so that the trace context can set metadata and log about incoming request start and complete.
3. Pass the response status and body to the trace context.
4. Relax the version requirements for swift-metrics


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
