### PR TITLE
Version 1.x compatible server type.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "1e42bb839956c0132d82b3cda20981eb81fbb532",
-          "version": "2.0.0-alpha.5"
+          "revision": "da6596f8602cc293a1d026f0c0dac3bd39e78ab0",
+          "version": "2.0.0-alpha.6"
         }
       },
       {

--- a/Sources/SmokeHTTP1/StandardSmokeHTTP1Server.swift
+++ b/Sources/SmokeHTTP1/StandardSmokeHTTP1Server.swift
@@ -22,21 +22,12 @@ import NIOExtras
 import Logging
 import SmokeInvocation
 
-public struct ServerDefaults {
-    static let defaultHost = "0.0.0.0"
-    public static let defaultPort = 8080
-}
-
-public enum SmokeHTTP1ServerError: Error {
-    case shutdownAttemptOnUnstartedServer
-}
-
 /**
  A basic non-blocking HTTP server that handles a request with an
  optional body and returns a response with an optional body.
  */
 public class StandardSmokeHTTP1Server<HTTP1RequestHandlerType: HTTP1RequestHandler,
-                                      InvocationContext: HTTP1RequestInvocationContext>: SmokeHTTP1Server
+                                      InvocationContext: HTTP1RequestInvocationContext>
         where HTTP1RequestHandlerType.ResponseHandlerType == StandardHTTP1ResponseHandler<InvocationContext> {
     let port: Int
     
@@ -89,7 +80,8 @@ public class StandardSmokeHTTP1Server<HTTP1RequestHandlerType: HTTP1RequestHandl
                 invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),
                 defaultLogger: Logger = Logger(label: "com.amazon.SmokeFramework.SmokeHTTP1.SmokeHTTP1Server"),
                 shutdownCompletionHandlerInvocationStrategy: InvocationStrategy = GlobalDispatchQueueSyncInvocationStrategy(),
-                eventLoopProvider: SmokeServerEventLoopProvider = .spawnNewThreads, shutdownOnSignal: SmokeServerShutdownOnSignal = .sigint) {
+                eventLoopProvider: SmokeHTTP1Server.EventLoopProvider = .spawnNewThreads,
+                shutdownOnSignal: SmokeHTTP1Server.ShutdownOnSignal = .sigint) {
         let signalQueue = DispatchQueue(label: "io.smokeframework.SmokeHTTP1Server.SignalHandlingQueue")
         
         self.port = port

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1Server+startAsOperationServer.swift
@@ -30,8 +30,8 @@ public extension SmokeHTTP1Server {
         invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),
         defaultLogger: Logger = Logger(label: "com.amazon.SmokeFramework.SmokeHTTP1Server"),
         reportingConfiguration: SmokeServerReportingConfiguration<SelectorType.OperationIdentifer> = SmokeServerReportingConfiguration(),
-        eventLoopProvider: SmokeServerEventLoopProvider = .spawnNewThreads,
-        shutdownOnSignal: SmokeServerShutdownOnSignal = .sigint) throws -> SmokeHTTP1Server
+        eventLoopProvider: EventLoopProvider = .spawnNewThreads,
+        shutdownOnSignal: ShutdownOnSignal = .sigint) throws -> SmokeHTTP1Server
         where HTTPRequestHead == SelectorType.DefaultOperationDelegateType.TraceContextType.RequestHeadType,
         SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
         SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
@@ -48,7 +48,7 @@ public extension SmokeHTTP1Server {
             
             try server.start()
             
-            return server
+            return SmokeHTTP1Server(wrappedServer: server)
     }
   
     static func startAsOperationServer<SelectorType: SmokeHTTP1HandlerSelector>(
@@ -59,8 +59,8 @@ public extension SmokeHTTP1Server {
         invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),
         defaultLogger: Logger = Logger(label: "com.amazon.SmokeFramework.SmokeHTTP1Server"),
         reportingConfiguration: SmokeServerReportingConfiguration<SelectorType.OperationIdentifer> = SmokeServerReportingConfiguration(),
-        eventLoopProvider: SmokeServerEventLoopProvider = .spawnNewThreads,
-        shutdownOnSignal: SmokeServerShutdownOnSignal = .sigint) throws -> SmokeHTTP1Server
+        eventLoopProvider: EventLoopProvider = .spawnNewThreads,
+        shutdownOnSignal: ShutdownOnSignal = .sigint) throws -> SmokeHTTP1Server
         where HTTPRequestHead == SelectorType.DefaultOperationDelegateType.TraceContextType.RequestHeadType,
         SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
         SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
@@ -77,6 +77,6 @@ public extension SmokeHTTP1Server {
             
             try server.start()
             
-            return server
+            return SmokeHTTP1Server(wrappedServer: server)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Revert to a concrete `SmokeHTTP1Server` type, wrapping an `StandardSmokeHTTP1Server` instance internally, type erasing the generic parameters and
 presenting the same external methods as SmokeFramework 1.x.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
