### PR TITLE
Return HTTP1ChannelInboundHandler to idle after response sent.

### DIFF
--- a/Sources/SmokeHTTP1/StandardHTTP1ResponseHandler.swift
+++ b/Sources/SmokeHTTP1/StandardHTTP1ResponseHandler.swift
@@ -28,6 +28,7 @@ public struct StandardHTTP1ResponseHandler<InvocationContext: HTTP1RequestInvoca
     let keepAliveStatus: KeepAliveStatus
     let context: ChannelHandlerContext
     let wrapOutboundOut: (_ value: HTTPServerResponsePart) -> NIOAny
+    let onComplete: () -> ()
     
     public func executeInEventLoop(invocationContext: InvocationContext, execute: @escaping () -> ()) {
         // if we are currently on a thread that can complete the response
@@ -121,6 +122,8 @@ public struct StandardHTTP1ResponseHandler<InvocationContext: HTTP1RequestInvoca
                 currentContext.close(promise: nil)
             }
         }
+        
+        onComplete()
         
         // write the response end and flush
         context.writeAndFlush(self.wrapOutboundOut(HTTPServerResponsePart.end(nil)),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Return HTTP1ChannelInboundHandler to idle after response sent.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
