### PR TITLE
Add Swift 5.2 CI tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.2-bionic USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.2-xenial USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE_TAG=swift:5.1.4-bionic USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial

--- a/CITests/run
+++ b/CITests/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-swiftLintVersion=0.36.0
+swiftLintVersion=0.39.1
 
 USE_SWIFT_LINT=$1
 
@@ -23,7 +23,7 @@ fi
 
 cd $workspaceRoot/package
 swift build -c release
-#swift test
+swift test
 
 if [ "$USE_SWIFT_LINT" == 'yes' ]; then
     swiftlint

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 <a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-5.1-orange.svg?style=flat" alt="Swift 5.1 Compatible">
 </a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.2-orange.svg?style=flat" alt="Swift 5.2 Compatible">
+</a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">
 </a>

--- a/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
@@ -25,9 +25,7 @@ import SmokeInvocation
 /**
  Handler that manages the inbound channel for a HTTP Request.
  */
-class HTTP1ChannelInboundHandler<HTTP1RequestHandlerType: HTTP1RequestHandler,
-                                 InvocationContext: HTTP1RequestInvocationContext>: ChannelInboundHandler
-        where HTTP1RequestHandlerType.ResponseHandlerType == StandardHTTP1ResponseHandler<InvocationContext> {
+class HTTP1ChannelInboundHandler<HTTP1RequestHandlerType: HTTP1RequestHandler>: ChannelInboundHandler {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
     
@@ -255,7 +253,7 @@ class HTTP1ChannelInboundHandler<HTTP1RequestHandlerType: HTTP1RequestHandler,
         }
         
         // create a response handler for this request
-        let responseHandler = StandardHTTP1ResponseHandler<HTTP1RequestHandlerType.ResponseHandlerType.InvocationContext>(
+        let responseHandler = HTTP1RequestHandlerType.ResponseHandlerType(
             requestHead: requestHead,
             keepAliveStatus: pendingResponse.keepAliveStatus,
             context: context,

--- a/Sources/SmokeHTTP1/HTTP1ResponseHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1ResponseHandler.swift
@@ -27,6 +27,22 @@ public protocol HTTP1ResponseHandler {
     associatedtype InvocationContext: HTTP1RequestInvocationContext
     
     /**
+     Initializer.
+     
+     - Parameters:
+         - requestHead: the head of the request that this handler will respond to.
+         - keepAliveStatus: if the request should be kept alive.
+         - context: the `ChannelHandlerContext` associated with the response.
+         - wrapOutboundOut: helper function to prepare a `HTTPServerResponsePart` for transmission on the channel.
+         - onComplete: to be called when the response has been sent on the channel.
+     */
+    init(requestHead: HTTPRequestHead,
+         keepAliveStatus: KeepAliveStatus,
+         context: ChannelHandlerContext,
+         wrapOutboundOut: @escaping (_ value: HTTPServerResponsePart) -> NIOAny,
+         onComplete: @escaping () -> ())
+    
+    /**
      Function used to provide a response to a HTTP request.
  
      - Parameters:

--- a/Sources/SmokeHTTP1/KeepAliveStatus.swift
+++ b/Sources/SmokeHTTP1/KeepAliveStatus.swift
@@ -21,7 +21,7 @@ import Foundation
  Class that shares the keepAlive status of a HTTP Request between the
  HTTPChannelInboundHandler and HttpResponseHandler.
  */
-class KeepAliveStatus {
+public class KeepAliveStatus {
     var state: Bool
     
     init(state: Bool) {

--- a/Sources/SmokeHTTP1/SmokeHTTP1Server.swift
+++ b/Sources/SmokeHTTP1/SmokeHTTP1Server.swift
@@ -67,8 +67,8 @@ public class SmokeHTTP1Server {
     private let waitUntilShutdownAndThenHandler: (_ onShutdown: @escaping () -> Void) throws -> ()
     private let onShutdownHandler: (_ onShutdown: @escaping () -> Void) throws -> ()
     
-    public init<HTTP1RequestHandlerType: HTTP1RequestHandler, InvocationContext: HTTP1RequestInvocationContext>(
-            wrappedServer: StandardSmokeHTTP1Server<HTTP1RequestHandlerType, InvocationContext>) {
+    public init<HTTP1RequestHandlerType: HTTP1RequestHandler>(
+            wrappedServer: StandardSmokeHTTP1Server<HTTP1RequestHandlerType>) {
         self.startHandler = {
             try wrappedServer.start()
         }

--- a/Sources/SmokeHTTP1/StandardHTTP1ResponseHandler.swift
+++ b/Sources/SmokeHTTP1/StandardHTTP1ResponseHandler.swift
@@ -30,6 +30,18 @@ public struct StandardHTTP1ResponseHandler<InvocationContext: HTTP1RequestInvoca
     let wrapOutboundOut: (_ value: HTTPServerResponsePart) -> NIOAny
     let onComplete: () -> ()
     
+    public init(requestHead: HTTPRequestHead,
+                keepAliveStatus: KeepAliveStatus,
+                context: ChannelHandlerContext,
+                wrapOutboundOut: @escaping (_ value: HTTPServerResponsePart) -> NIOAny,
+                onComplete: @escaping () -> ()) {
+        self.requestHead = requestHead
+        self.keepAliveStatus = keepAliveStatus
+        self.context = context
+        self.wrapOutboundOut = wrapOutboundOut
+        self.onComplete = onComplete
+    }
+    
     public func executeInEventLoop(invocationContext: InvocationContext, execute: @escaping () -> ()) {
         // if we are currently on a thread that can complete the response
         if context.eventLoop.inEventLoop {

--- a/Sources/SmokeHTTP1/StandardSmokeHTTP1Server.swift
+++ b/Sources/SmokeHTTP1/StandardSmokeHTTP1Server.swift
@@ -26,9 +26,7 @@ import SmokeInvocation
  A basic non-blocking HTTP server that handles a request with an
  optional body and returns a response with an optional body.
  */
-public class StandardSmokeHTTP1Server<HTTP1RequestHandlerType: HTTP1RequestHandler,
-                                      InvocationContext: HTTP1RequestInvocationContext>
-        where HTTP1RequestHandlerType.ResponseHandlerType == StandardHTTP1ResponseHandler<InvocationContext> {
+public class StandardSmokeHTTP1Server<HTTP1RequestHandlerType: HTTP1RequestHandler> {
     let port: Int
     
     let quiesce: ServerQuiescingHelper
@@ -159,8 +157,7 @@ public class StandardSmokeHTTP1Server<HTTP1RequestHandlerType: HTTP1RequestHandl
             }
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline().flatMap {
-                    channel.pipeline.addHandler(HTTP1ChannelInboundHandler<HTTP1RequestHandlerType,
-                                                    HTTP1RequestHandlerType.ResponseHandlerType.InvocationContext>(
+                    channel.pipeline.addHandler(HTTP1ChannelInboundHandler<HTTP1RequestHandlerType>(
                         handler: currentHandler,
                         invocationStrategy: currentInvocationStrategy))
                 }

--- a/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
@@ -20,6 +20,7 @@ import NIOHTTP1
 import SmokeHTTP1
 import Logging
 import SmokeInvocation
+import NIO
 @testable import SmokeOperationsHTTP1
 import XCTest
 
@@ -67,6 +68,16 @@ struct TestOperationTraceContext: HTTP1OperationTraceContext {
 
 class TestHttpResponseHandler: HTTP1ResponseHandler {
     var response: OperationResponse?
+    
+    init() {
+        
+    }
+    
+    required init(requestHead: HTTPRequestHead, keepAliveStatus: KeepAliveStatus,
+                  context: ChannelHandlerContext, wrapOutboundOut: @escaping (HTTPServerResponsePart) -> NIOAny,
+                  onComplete: @escaping () -> ()) {
+        // nothing to do
+    }
     
     func complete(invocationContext: SmokeServerInvocationContext<TestOperationTraceContext>, status: HTTPResponseStatus,
                   responseComponents: HTTP1ServerResponseComponents) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add Swift 5.2 CI tests.
2. Simplify generics code by removing explicit initalization of StandardHTTP1ResponseHandler in the HTTP1ChannelInboundHandler.
3. Re-enable tests.

This resolves #49 by eliminating the situation that was triggering the compiler bug.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
