### PR TITLE
Add constructor for SmokeInvocationTraceContext.

### DIFF
--- a/Sources/SmokeOperationsHTTP1Server/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeInvocationTraceContext.swift
@@ -48,6 +48,12 @@ private let traceIdHeader = "x-smoke-trace-id"
 public struct SmokeInvocationTraceContext {
     private let externalRequestId: String?
     private let traceId: String?
+    
+    public init(externalRequestId: String? = nil,
+                traceId: String? = nil) {
+        self.externalRequestId = externalRequestId
+        self.traceId = traceId
+    }
 }
 
 extension SmokeInvocationTraceContext: HTTP1OperationTraceContext {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add constructor for SmokeInvocationTraceContext to be able to construct the context manually from outside of a framework invocation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
