### PR TITLE
Support for returning EventLoopFutures directly from operation handlers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,7 +11,7 @@
         }
       },
       {
-        "package": "SmokeHTTP",
+        "package": "smoke-http",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,7 +11,7 @@
         }
       },
       {
-        "package": "smoke-http",
+        "package": "SmokeHTTP",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,12 @@ let package = Package(
         .library(
             name: "SmokeHTTP1",
             targets: ["SmokeHTTP1"]),
+        .library(
+            name: "SmokeAsync",
+            targets: ["SmokeAsync"]),
+        .library(
+            name: "SmokeAsyncHTTP1",
+            targets: ["SmokeAsyncHTTP1"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
@@ -76,6 +82,17 @@ let package = Package(
             name: "SmokeOperationsHTTP1Server", dependencies: [
                 .target(name: "SmokeOperationsHTTP1"),
                 .target(name: "SmokeHTTP1"),
+            ]),
+        .target(
+            name: "SmokeAsync", dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIO", package: "swift-nio"),
+                .target(name: "SmokeOperations"),
+            ]),
+        .target(
+            name: "SmokeAsyncHTTP1", dependencies: [
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .target(name: "SmokeOperationsHTTP1"),
             ]),
         .testTarget(
             name: "SmokeOperationsHTTP1Tests", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -92,6 +92,7 @@ let package = Package(
         .target(
             name: "SmokeAsyncHTTP1", dependencies: [
                 .product(name: "NIOHTTP1", package: "swift-nio"),
+                .target(name: "SmokeAsync"),
                 .target(name: "SmokeOperationsHTTP1"),
             ]),
         .testTarget(

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -36,6 +36,12 @@ let package = Package(
         .library(
             name: "SmokeHTTP1",
             targets: ["SmokeHTTP1"]),
+        .library(
+            name: "SmokeAsync",
+            targets: ["SmokeAsync"]),
+        .library(
+            name: "SmokeAsyncHTTP1",
+            targets: ["SmokeAsyncHTTP1"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
@@ -61,6 +67,12 @@ let package = Package(
         .target(
             name: "SmokeOperationsHTTP1Server",
             dependencies: ["SmokeOperationsHTTP1", "SmokeHTTP1"]),
+        .target(
+            name: "SmokeAsync",
+            dependencies: ["Logging", "NIO", "SmokeOperations"]),
+        .target(
+            name: "SmokeAsyncHTTP1",
+            dependencies: ["NIOHTTP1", "SmokeOperationsHTTP1"]),
         .testTarget(
             name: "SmokeOperationsHTTP1Tests",
             dependencies: ["SmokeOperationsHTTP1"]),

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -72,7 +72,7 @@ let package = Package(
             dependencies: ["Logging", "NIO", "SmokeOperations"]),
         .target(
             name: "SmokeAsyncHTTP1",
-            dependencies: ["NIOHTTP1", "SmokeOperationsHTTP1"]),
+            dependencies: ["NIOHTTP1", "SmokeOperationsHTTP1", "SmokeAsync"]),
         .testTarget(
             name: "SmokeOperationsHTTP1Tests",
             dependencies: ["SmokeOperationsHTTP1"]),

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -36,6 +36,12 @@ let package = Package(
         .library(
             name: "SmokeHTTP1",
             targets: ["SmokeHTTP1"]),
+        .library(
+            name: "SmokeAsync",
+            targets: ["SmokeAsync"]),
+        .library(
+            name: "SmokeAsyncHTTP1",
+            targets: ["SmokeAsyncHTTP1"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
@@ -61,6 +67,12 @@ let package = Package(
         .target(
             name: "SmokeOperationsHTTP1Server",
             dependencies: ["SmokeOperationsHTTP1", "SmokeHTTP1"]),
+        .target(
+            name: "SmokeAsync",
+            dependencies: ["Logging", "NIO", "SmokeOperations"]),
+        .target(
+            name: "SmokeAsyncHTTP1",
+            dependencies: ["NIOHTTP1", "SmokeOperationsHTTP1"]),
         .testTarget(
             name: "SmokeOperationsHTTP1Tests",
             dependencies: ["SmokeOperationsHTTP1"]),

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -72,7 +72,7 @@ let package = Package(
             dependencies: ["Logging", "NIO", "SmokeOperations"]),
         .target(
             name: "SmokeAsyncHTTP1",
-            dependencies: ["NIOHTTP1", "SmokeOperationsHTTP1"]),
+            dependencies: ["NIOHTTP1", "SmokeOperationsHTTP1", "SmokeAsync"]),
         .testTarget(
             name: "SmokeOperationsHTTP1Tests",
             dependencies: ["SmokeOperationsHTTP1"]),

--- a/Sources/SmokeAsync/OperationHandler+futureWithContextInputNoOutput.swift
+++ b/Sources/SmokeAsync/OperationHandler+futureWithContextInputNoOutput.swift
@@ -1,0 +1,110 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OperationHandler+futureWithContextInputNoOutput.swift
+// SmokeAsync
+//
+
+import Foundation
+import Logging
+import SmokeOperations
+import NIO
+
+public extension OperationHandler {
+    /**
+       Initializer for non-blocking operation handler that has input
+       returns a result with an empty body.
+     
+     - Parameters:
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer,
+            reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType,
+                       InvocationReportingType) throws -> EventLoopFuture<Void>),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it the responseHandler is
+         * called to indicate success when the input handler's response handler is called. If the provided operation
+         * provides an error, the responseHandler is called with that error.
+         */
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
+            responseHandler: ResponseHandlerType, invocationContext: SmokeInvocationContext<InvocationReportingType>) in
+            let handlerResult: NoOutputOperationHandlerResult<ErrorType>?
+            do {
+                let future = try operation(input, context, invocationContext.invocationReporting)
+                
+                future.whenComplete { result in
+                    let asyncHandlerResult: NoOutputOperationHandlerResult<ErrorType>
+                    
+                    switch result {
+                    case .failure(let error):
+                        if let smokeReturnableError = error as? SmokeReturnableError {
+                            asyncHandlerResult = .smokeReturnableError(smokeReturnableError,
+                                                                       allowedErrors)
+                        } else if case SmokeOperationsError.validationError(reason: let reason) = error {
+                            asyncHandlerResult = .validationError(reason)
+                        } else {
+                            asyncHandlerResult = .internalServerError(error)
+                        }
+                    case .success:
+                        asyncHandlerResult = .success
+                    }
+                    
+                    OperationHandler.handleNoOutputOperationHandlerResult(
+                        handlerResult: asyncHandlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        invocationContext: invocationContext)
+                }
+                
+                // no immediate result
+                handlerResult = nil
+            } catch let smokeReturnableError as SmokeReturnableError {
+                handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+            } catch SmokeOperationsError.validationError(reason: let reason) {
+                handlerResult = .validationError(reason)
+            } catch {
+                handlerResult = .internalServerError(error)
+            }
+            
+            // if this handler is throwing an error immediately
+            if let handlerResult = handlerResult {
+                OperationHandler.handleNoOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeAsync/OperationHandler+futureWithContextInputWithOutput.swift
+++ b/Sources/SmokeAsync/OperationHandler+futureWithContextInputWithOutput.swift
@@ -1,0 +1,113 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  OperationHandler+futureWithContextInputWithOutput.swift
+//  SmokeOperations
+//
+
+import Foundation
+import Logging
+import SmokeOperations
+import NIO
+
+public extension OperationHandler {
+    /**
+       Initializer for non-blocking operation handler that has input
+       returns a result body.
+     
+     - Parameters:
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, OutputType: Validatable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType, InvocationReportingType) throws -> EventLoopFuture<OutputType>),
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeInvocationContext<InvocationReportingType>) -> Void),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it the responseHandler is
+         * called with the result when the input handler's response handler is called. If the provided operation
+         * provides an error, the responseHandler is called with that error.
+         */
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
+            responseHandler: ResponseHandlerType, invocationContext: SmokeInvocationContext<InvocationReportingType>) in
+            let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>?
+            do {
+                let future = try operation(input, context, invocationContext.invocationReporting)
+                
+                future.whenComplete { result in
+                    let asyncHandlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
+                    
+                    switch result {
+                    case .success(let result):
+                        asyncHandlerResult = .success(result)
+                    case .failure(let error):
+                        if let smokeReturnableError = error as? SmokeReturnableError {
+                            asyncHandlerResult = .smokeReturnableError(smokeReturnableError,
+                                                                       allowedErrors)
+                        } else if case SmokeOperationsError.validationError(reason: let reason) = error {
+                            asyncHandlerResult = .validationError(reason)
+                        } else {
+                            asyncHandlerResult = .internalServerError(error)
+                        }
+                    }
+                    
+                    OperationHandler.handleWithOutputOperationHandlerResult(
+                        handlerResult: asyncHandlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        outputHandler: outputHandler,
+                        invocationContext: invocationContext)
+                }
+                
+                // no immediate result
+                handlerResult = nil
+            } catch let smokeReturnableError as SmokeReturnableError {
+                handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+            } catch SmokeOperationsError.validationError(reason: let reason) {
+                handlerResult = .validationError(reason)
+            } catch {
+                handlerResult = .internalServerError(error)
+            }
+            
+            // if this handler is throwing an error immediately
+            if let handlerResult = handlerResult {
+                OperationHandler.handleWithOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    outputHandler: outputHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeAsync/OperationHandler+futureWithInputNoOutput.swift
+++ b/Sources/SmokeAsync/OperationHandler+futureWithInputNoOutput.swift
@@ -1,0 +1,114 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OperationHandler+futureWithInputNoOutput.swift
+// SmokeAsync
+//
+
+import Foundation
+import Logging
+import SmokeOperations
+import NIO
+
+public extension OperationHandler {
+    /**
+       Initializer for non-blocking operation handler that has input
+       returns a result with an empty body.
+     
+     - Parameters:
+        - serverName: the name of the server this operation is part of.
+        - operationIdentifer: the identifer for the operation being handled.
+        - reportingConfiguration: the configuration for how operations on this server should be reported on.
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer,
+            reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<Void>),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it the responseHandler is
+         * called to indicate success when the input handler's response handler is called. If the provided operation
+         * provides an error, the responseHandler is called with that error.
+         */
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
+            responseHandler: ResponseHandlerType, invocationContext: SmokeInvocationContext<InvocationReportingType>) in
+            let handlerResult: NoOutputOperationHandlerResult<ErrorType>?
+            do {
+                let future = try operation(input, context)
+                
+                future.whenComplete { result in
+                    let asyncHandlerResult: NoOutputOperationHandlerResult<ErrorType>
+                    
+                    switch result {
+                    case .failure(let error):
+                        if let smokeReturnableError = error as? SmokeReturnableError {
+                            asyncHandlerResult = .smokeReturnableError(smokeReturnableError,
+                                                                       allowedErrors)
+                        } else if case SmokeOperationsError.validationError(reason: let reason) = error {
+                            asyncHandlerResult = .validationError(reason)
+                        } else {
+                            asyncHandlerResult = .internalServerError(error)
+                        }
+                    case .success:
+                        asyncHandlerResult = .success
+                    }
+                    
+                    OperationHandler.handleNoOutputOperationHandlerResult(
+                        handlerResult: asyncHandlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        invocationContext: invocationContext)
+                }
+                
+                // no immediate result
+                handlerResult = nil
+            } catch let smokeReturnableError as SmokeReturnableError {
+                handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+            } catch SmokeOperationsError.validationError(reason: let reason) {
+                handlerResult = .validationError(reason)
+            } catch {
+                handlerResult = .internalServerError(error)
+            }
+            
+            // if this handler is throwing an error immediately
+            if let handlerResult = handlerResult {
+                OperationHandler.handleNoOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName,
+                  operationIdentifer: operationIdentifer,
+                  reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeAsync/OperationHandler+futureWithInputWithOutput.swift
+++ b/Sources/SmokeAsync/OperationHandler+futureWithInputWithOutput.swift
@@ -1,0 +1,119 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  OperationHandler+futureWithInputWithOutput.swift
+//  SmokeOperations
+//
+
+import Foundation
+import Logging
+import SmokeOperations
+import NIO
+
+public extension OperationHandler {
+    /**
+       Initializer for non-blocking operation handler that has input
+       returns a result body.
+     
+     - Parameters:
+        - serverName: the name of the server this operation is part of.
+        - operationIdentifer: the identifer for the operation being handled.
+        - reportingConfiguration: the configuration for how operations on this server should be reported on.
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, OutputType: Validatable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer,
+            reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<OutputType>),
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeInvocationContext<InvocationReportingType>) -> Void),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it the responseHandler is
+         * called with the result when the input handler's response handler is called. If the provided operation
+         * provides an error, the responseHandler is called with that error.
+         */
+        let wrappedInputHandler = { (input: InputType, requestHead: RequestHeadType, context: ContextType,
+            responseHandler: ResponseHandlerType, invocationContext: SmokeInvocationContext<InvocationReportingType>) in
+            let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>?
+            do {
+                let future = try operation(input, context)
+                
+                future.whenComplete { result in
+                    let asyncHandlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
+                    
+                    switch result {
+                    case .success(let result):
+                        asyncHandlerResult = .success(result)
+                    case .failure(let error):
+                        if let smokeReturnableError = error as? SmokeReturnableError {
+                            asyncHandlerResult = .smokeReturnableError(smokeReturnableError,
+                                                                       allowedErrors)
+                        } else if case SmokeOperationsError.validationError(reason: let reason) = error {
+                            asyncHandlerResult = .validationError(reason)
+                        } else {
+                            asyncHandlerResult = .internalServerError(error)
+                        }
+                    }
+                    
+                    OperationHandler.handleWithOutputOperationHandlerResult(
+                        handlerResult: asyncHandlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        outputHandler: outputHandler,
+                        invocationContext: invocationContext)
+                }
+                
+                // no immediate result
+                handlerResult = nil
+            } catch let smokeReturnableError as SmokeReturnableError {
+                handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+            } catch SmokeOperationsError.validationError(reason: let reason) {
+                handlerResult = .validationError(reason)
+            } catch {
+                handlerResult = .internalServerError(error)
+            }
+            
+            // if this handler is throwing an error immediately
+            if let handlerResult = handlerResult {
+                OperationHandler.handleWithOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    outputHandler: outputHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName,
+                  operationIdentifer: operationIdentifer,
+                  reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeAsyncHTTP1/SmokeHTTP1HandlerSelector+futureWithContextInputNoOutput.swift
+++ b/Sources/SmokeAsyncHTTP1/SmokeHTTP1HandlerSelector+futureWithContextInputNoOutput.swift
@@ -1,0 +1,164 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+futureWithContextInputNoOutput.swift
+// SmokeAsyncHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIO
+import NIOHTTP1
+import SmokeOperationsHTTP1
+import SmokeAsync
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType,
+                   InvocationReportingType) throws -> EventLoopFuture<Void>),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate> (
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType,
+                   InvocationReportingType) throws -> EventLoopFuture<Void>),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType,
+                   InvocationReportingType) throws -> EventLoopFuture<Void>),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType,
+                   InvocationReportingType) throws -> EventLoopFuture<Void>),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}

--- a/Sources/SmokeAsyncHTTP1/SmokeHTTP1HandlerSelector+futureWithContextInputWithOutput.swift
+++ b/Sources/SmokeAsyncHTTP1/SmokeHTTP1HandlerSelector+futureWithContextInputWithOutput.swift
@@ -1,0 +1,192 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  SmokeHTTP1HandlerSelector+futureWithContextInputWithOutput.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import SmokeOperationsHTTP1
+import NIO
+import SmokeAsync
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType,
+            InvocationReportingType) throws -> EventLoopFuture<OutputType>),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
+                           output: OutputType,
+                           responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
+                           invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+            delegateToUse.handleResponseForOperation(requestHead: requestHead,
+                                                     location: outputLocation,
+                                                     output: output,
+                                                     responseHandler: responseHandler,
+                                                     invocationContext: invocationContext)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            outputHandler: outputHandler,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType,
+            InvocationReportingType) throws -> EventLoopFuture<OutputType>),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
+                               output: OutputType,
+                               responseHandler: OperationDelegateType.ResponseHandlerType,
+                               invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+                operationDelegate.handleResponseForOperation(requestHead: requestHead,
+                                                             location: outputLocation,
+                                                             output: output,
+                                                             responseHandler: responseHandler,
+                                                             invocationContext: invocationContext)
+            }
+            
+            let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                outputHandler: outputHandler,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType,
+            InvocationReportingType) throws -> EventLoopFuture<OutputType>),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: defaultOperationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType,
+            InvocationReportingType) throws -> EventLoopFuture<OutputType>),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: operationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}

--- a/Sources/SmokeAsyncHTTP1/SmokeHTTP1HandlerSelector+futureWithInputNoOutput.swift
+++ b/Sources/SmokeAsyncHTTP1/SmokeHTTP1HandlerSelector+futureWithInputNoOutput.swift
@@ -1,0 +1,164 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+futureWithInputNoOutput.swift
+// SmokeAsyncHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import SmokeOperationsHTTP1
+import NIO
+import SmokeAsync
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<Void>),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<Void>),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            let handler = OperationHandler(
+                serverName: serverName, operationIdentifer: operationIdentifer,
+                reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<Void>),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<Void>),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}

--- a/Sources/SmokeAsyncHTTP1/SmokeHTTP1HandlerSelector+futureWithInputWithOutput.swift
+++ b/Sources/SmokeAsyncHTTP1/SmokeHTTP1HandlerSelector+futureWithInputWithOutput.swift
@@ -1,0 +1,192 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  SmokeHTTP1HandlerSelector+futureWithInputWithOutput.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import SmokeOperationsHTTP1
+import NIO
+import SmokeAsync
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<OutputType>),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
+                           output: OutputType,
+                           responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
+                           invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+            delegateToUse.handleResponseForOperation(requestHead: requestHead,
+                                                     location: outputLocation,
+                                                     output: output,
+                                                     responseHandler: responseHandler,
+                                                     invocationContext: invocationContext)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            outputHandler: outputHandler,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<OutputType>),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
+                               output: OutputType,
+                               responseHandler: OperationDelegateType.ResponseHandlerType,
+                               invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+                operationDelegate.handleResponseForOperation(requestHead: requestHead,
+                                                             location: outputLocation,
+                                                             output: output,
+                                                             responseHandler: responseHandler,
+                                                             invocationContext: invocationContext)
+            }
+            
+            let handler = OperationHandler(
+                serverName: serverName, operationIdentifer: operationIdentifer,
+                reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                outputHandler: outputHandler,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<OutputType>),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: defaultOperationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) throws -> EventLoopFuture<OutputType>),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: operationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
@@ -41,7 +41,7 @@ public extension SmokeHTTP1Server {
             } catch {
                 let logger = Logger.init(label: "application.initialization")
                 
-                logger.error("Unable to inialize DynamoDB Table - \(error).")
+                logger.error("Unable to inialize application from factory due to error - \(error).")
                 
                 return
             }
@@ -91,8 +91,8 @@ public extension SmokeHTTP1Server {
             } catch {
                 let logger = Logger.init(label: "application.initialization")
                 
-                logger.error("Unable to inialize DynamoDB Table - \(error).")
-                
+                logger.error("Unable to inialize application from factory due to error - \(error).")
+
                 return
             }
             


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Support more advanced async use-cases by providing an integration to directly return EventLoopFutures from operation handlers
2. Fix a copy-and-paste error where the logging for application initialisation was not relevant.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
