### PR TITLE
Improve default trace logging at info and debug levels.

### DIFF
--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
@@ -41,7 +41,7 @@ public extension SmokeHTTP1Server {
             } catch {
                 let logger = Logger.init(label: "application.initialization")
                 
-                logger.error("Unable to inialize application from factory due to error - \(error).")
+                logger.error("Unable to initialize application from factory due to error - \(error).")
                 
                 return
             }
@@ -91,7 +91,7 @@ public extension SmokeHTTP1Server {
             } catch {
                 let logger = Logger.init(label: "application.initialization")
                 
-                logger.error("Unable to inialize application from factory due to error - \(error).")
+                logger.error("Unable to initialize application from factory due to error - \(error).")
 
                 return
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Log basic outgoing request log line at info
2. Log outgoing body at info
3. Log 400 response log line at warning rather than warning


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
