### PR TITLE
SmokeHTTP1Server.runAsOperationServer overloads

### DIFF
--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
@@ -33,7 +33,7 @@ public extension SmokeHTTP1Server {
         InitializerType.SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
         StandardHTTP1ResponseHandler<SmokeInvocationContext<InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType>> {
             func wrappedFactory(eventLoopGroup: EventLoopGroup) throws -> InitializerType {
-                try factory(eventLoopGroup.next())
+                return try factory(eventLoopGroup.next())
             }
             
             runAsOperationServer(wrappedFactory)
@@ -46,7 +46,7 @@ public extension SmokeHTTP1Server {
         InitializerType.SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
         StandardHTTP1ResponseHandler<SmokeInvocationContext<InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType>> {
             func wrappedFactory(eventLoopGroup: EventLoopGroup) throws -> InitializerType {
-                try factory(eventLoopGroup.next())
+                return try factory(eventLoopGroup.next())
             }
             
             runAsOperationServer(wrappedFactory)

--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
@@ -32,48 +32,11 @@ public extension SmokeHTTP1Server {
         InitializerType.SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
         InitializerType.SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
         StandardHTTP1ResponseHandler<SmokeInvocationContext<InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType>> {
-            let eventLoopGroup =
-                MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-            
-            let initalizer: InitializerType
-            do {
-                initalizer = try factory(eventLoopGroup.next())
-            } catch {
-                let logger = Logger.init(label: "application.initialization")
-                
-                logger.error("Unable to initialize application from factory due to error - \(error).")
-                
-                return
+            func wrappedFactory(eventLoopGroup: EventLoopGroup) throws -> InitializerType {
+                try factory(eventLoopGroup.next())
             }
             
-            // initialize the logger after instatiating the initializer
-            let logger = Logger.init(label: "application.initialization")
-            
-            let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
-                handlerSelector: initalizer.handlerSelector,
-                context: initalizer.getInvocationContext(), serverName: initalizer.serverName,
-                reportingConfiguration: initalizer.reportingConfiguration)
-            let server = StandardSmokeHTTP1Server(handler: handler,
-                                                  port: initalizer.port,
-                                                  invocationStrategy: initalizer.invocationStrategy,
-                                                  defaultLogger: initalizer.defaultLogger,
-                                                  eventLoopProvider: initalizer.eventLoopProvider,
-                                                  shutdownOnSignal: initalizer.shutdownOnSignal)
-            do {
-                try server.start()
-                
-                try server.waitUntilShutdownAndThen {
-                    do {
-                        try initalizer.onShutdown()
-                        
-                        try eventLoopGroup.syncShutdownGracefully()
-                    } catch {
-                        logger.error("Unable to shutdown cleanly: '\(error)'")
-                    }
-                }
-            } catch {
-                logger.error("Unable to start Operations Server: '\(error)'")
-            }
+            runAsOperationServer(wrappedFactory)
     }
   
     static func runAsOperationServer<InitializerType: SmokeServerPerInvocationContextInitializer, TraceContextType>(
@@ -82,47 +45,110 @@ public extension SmokeHTTP1Server {
         InitializerType.SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
         InitializerType.SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
         StandardHTTP1ResponseHandler<SmokeInvocationContext<InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType>> {
-            let eventLoopGroup =
-                MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-            
-            let initalizer: InitializerType
-            do {
-                initalizer = try factory(eventLoopGroup.next())
-            } catch {
-                let logger = Logger.init(label: "application.initialization")
-                
-                logger.error("Unable to initialize application from factory due to error - \(error).")
-
-                return
+            func wrappedFactory(eventLoopGroup: EventLoopGroup) throws -> InitializerType {
+                try factory(eventLoopGroup.next())
             }
             
-            // initialize the logger after instatiating the initializer
-            let logger = Logger.init(label: "application.initialization")
-            
-            let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
-                handlerSelector: initalizer.handlerSelector,
-                contextProvider: initalizer.getInvocationContext, serverName: initalizer.serverName,
-                reportingConfiguration: initalizer.reportingConfiguration)
-            let server = StandardSmokeHTTP1Server(handler: handler,
-                                                  port: initalizer.port,
-                                                  invocationStrategy: initalizer.invocationStrategy,
-                                                  defaultLogger: initalizer.defaultLogger,
-                                                  eventLoopProvider: initalizer.eventLoopProvider,
-                                                  shutdownOnSignal: initalizer.shutdownOnSignal)
-            do {
-                try server.start()
-                
-                try server.waitUntilShutdownAndThen {
-                    do {
-                        try initalizer.onShutdown()
-                        
-                        try eventLoopGroup.syncShutdownGracefully()
-                    } catch {
-                        logger.error("Unable to shutdown cleanly: '\(error)'")
-                    }
-                }
-            } catch {
-                logger.error("Unable to start Operations Server: '\(error)'")
-            }
+            runAsOperationServer(wrappedFactory)
     }
+    
+    static func runAsOperationServer<InitializerType: SmokeServerStaticContextInitializer, TraceContextType>(
+          _ factory: @escaping (EventLoopGroup) throws -> InitializerType)
+          where InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType == SmokeServerInvocationReporting<TraceContextType>,
+          InitializerType.SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
+          InitializerType.SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
+          StandardHTTP1ResponseHandler<SmokeInvocationContext<InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType>> {
+              let eventLoopGroup =
+                  MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+              
+              let initalizer: InitializerType
+              do {
+                  initalizer = try factory(eventLoopGroup)
+              } catch {
+                  let logger = Logger.init(label: "application.initialization")
+                  
+                  logger.error("Unable to initialize application from factory due to error - \(error).")
+                  
+                  return
+              }
+              
+              // initialize the logger after instatiating the initializer
+              let logger = Logger.init(label: "application.initialization")
+              
+              let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
+                  handlerSelector: initalizer.handlerSelector,
+                  context: initalizer.getInvocationContext(), serverName: initalizer.serverName,
+                  reportingConfiguration: initalizer.reportingConfiguration)
+              let server = StandardSmokeHTTP1Server(handler: handler,
+                                                    port: initalizer.port,
+                                                    invocationStrategy: initalizer.invocationStrategy,
+                                                    defaultLogger: initalizer.defaultLogger,
+                                                    eventLoopProvider: initalizer.eventLoopProvider,
+                                                    shutdownOnSignal: initalizer.shutdownOnSignal)
+              do {
+                  try server.start()
+                  
+                  try server.waitUntilShutdownAndThen {
+                      do {
+                          try initalizer.onShutdown()
+                          
+                          try eventLoopGroup.syncShutdownGracefully()
+                      } catch {
+                          logger.error("Unable to shutdown cleanly: '\(error)'")
+                      }
+                  }
+              } catch {
+                  logger.error("Unable to start Operations Server: '\(error)'")
+              }
+      }
+    
+      static func runAsOperationServer<InitializerType: SmokeServerPerInvocationContextInitializer, TraceContextType>(
+          _ factory: @escaping (EventLoopGroup) throws -> InitializerType)
+          where InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType == SmokeServerInvocationReporting<TraceContextType>,
+          InitializerType.SelectorType.DefaultOperationDelegateType.RequestHeadType == SmokeHTTP1RequestHead,
+          InitializerType.SelectorType.DefaultOperationDelegateType.ResponseHandlerType ==
+          StandardHTTP1ResponseHandler<SmokeInvocationContext<InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType>> {
+              let eventLoopGroup =
+                  MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+              
+              let initalizer: InitializerType
+              do {
+                  initalizer = try factory(eventLoopGroup)
+              } catch {
+                  let logger = Logger.init(label: "application.initialization")
+                  
+                  logger.error("Unable to initialize application from factory due to error - \(error).")
+
+                  return
+              }
+              
+              // initialize the logger after instatiating the initializer
+              let logger = Logger.init(label: "application.initialization")
+              
+              let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
+                  handlerSelector: initalizer.handlerSelector,
+                  contextProvider: initalizer.getInvocationContext, serverName: initalizer.serverName,
+                  reportingConfiguration: initalizer.reportingConfiguration)
+              let server = StandardSmokeHTTP1Server(handler: handler,
+                                                    port: initalizer.port,
+                                                    invocationStrategy: initalizer.invocationStrategy,
+                                                    defaultLogger: initalizer.defaultLogger,
+                                                    eventLoopProvider: initalizer.eventLoopProvider,
+                                                    shutdownOnSignal: initalizer.shutdownOnSignal)
+              do {
+                  try server.start()
+                  
+                  try server.waitUntilShutdownAndThen {
+                      do {
+                          try initalizer.onShutdown()
+                          
+                          try eventLoopGroup.syncShutdownGracefully()
+                      } catch {
+                          logger.error("Unable to shutdown cleanly: '\(error)'")
+                      }
+                  }
+              } catch {
+                  logger.error("Unable to start Operations Server: '\(error)'")
+              }
+      }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Provide overloads of SmokeHTTP1Server.runAsOperationServer where the factory accepts the entire `EventLoopGroup` rather than just an `EventLoop`. Delegate the existing functions to the newer ones using a wrappedFactory that gets an `EventLoop` from the provided `EventLoopGroup`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
