### PR TITLE
Expose the request's eventLoop in SmokeServerInvocationReporting

### DIFF
--- a/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
@@ -288,6 +288,7 @@ class HTTP1ChannelInboundHandler<HTTP1RequestHandlerType: HTTP1RequestHandler>: 
                               responseHandler: responseHandler,
                               invocationStrategy: invocationStrategy,
                               requestLogger: logger,
+                              eventLoop: context.eventLoop,
                               internalRequestId: pendingResponse.internalRequestId)
     }
     

--- a/Sources/SmokeHTTP1/HTTP1RequestHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1RequestHandler.swift
@@ -35,7 +35,34 @@ public protocol HTTP1RequestHandler {
         - body: the body of the request, if any.
         - responseHandler: a handler that can be used to respond to the request.
         - invocationStrategy: the invocationStrategy to use for this request.
+        - requestLogger: the logger to use for this request.
+        - internalRequestId: the internal identifier for this request.
      */
     func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                 invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String)
+    
+    /**
+     Handles an incoming request.
+ 
+     - Parameters:
+         - requestHead: the parameters specified in the head of the HTTP request.
+         - body: the body of the request, if any.
+         - responseHandler: a handler that can be used to respond to the request.
+         - invocationStrategy: the invocationStrategy to use for this request.
+         - requestLogger: the logger to use for this request.
+         - eventLoop: the event loop used for this request.
+         - internalRequestId: the internal identifier for this request.
+     */
+    func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
+                invocationStrategy: InvocationStrategy, requestLogger: Logger, eventLoop: EventLoop?, internalRequestId: String)
+}
+
+public extension HTTP1RequestHandler {
+    // The function is being added as a non-breaking change, so add a default implementation that delegates to the existing
+    // function that must be implemented.
+    func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
+                invocationStrategy: InvocationStrategy, requestLogger: Logger, eventLoop: EventLoop?, internalRequestId: String) {
+        handle(requestHead: requestHead, body: body, responseHandler: responseHandler, invocationStrategy: invocationStrategy,
+               requestLogger: requestLogger, internalRequestId: internalRequestId)
+    }
 }

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting.swift
@@ -18,6 +18,7 @@
 import Foundation
 import SmokeOperations
 import Logging
+import NIO
 
 public protocol InvocationReportingWithTraceContext: InvocationReporting {
     associatedtype TraceContextType: OperationTraceContext
@@ -30,11 +31,13 @@ public protocol InvocationReportingWithTraceContext: InvocationReporting {
  */
 public struct SmokeServerInvocationReporting<TraceContextType: OperationTraceContext>: InvocationReportingWithTraceContext {
     public let logger: Logger
+    public let eventLoop: EventLoop?
     public let internalRequestId: String
     public let traceContext: TraceContextType
     
-    public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType) {
+    public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType, eventLoop: EventLoop? = nil) {
         self.logger = logger
+        self.eventLoop = eventLoop
         self.internalRequestId = internalRequestId
         self.traceContext = traceContext
     }


### PR DESCRIPTION

*Issue #, if available:* Expose the request's eventLoop in the SmokeServerInvocationReporting instance. Add a new function requirement to the `HTTP1RequestHandler` protocol but with a default implementation to avoid a breaking change.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
