### PR TITLE
Use the same event loop group for the initializer and server when possible

### DIFF
--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
@@ -26,6 +26,7 @@ import AsyncHTTPClient
 import SmokeInvocation
 
 public extension SmokeHTTP1Server {
+    @available(swift, deprecated: 3.0, message: "Provide an initializer that accepts an EventLoopGroup instance.")
     static func runAsOperationServer<InitializerType: SmokeServerStaticContextInitializer, TraceContextType>(
         _ factory: @escaping (EventLoop) throws -> InitializerType)
         where InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType == SmokeServerInvocationReporting<TraceContextType>,
@@ -39,6 +40,7 @@ public extension SmokeHTTP1Server {
             runAsOperationServer(wrappedFactory)
     }
   
+    @available(swift, deprecated: 3.0, message: "Provide an initializer that accepts an EventLoopGroup instance.")
     static func runAsOperationServer<InitializerType: SmokeServerPerInvocationContextInitializer, TraceContextType>(
         _ factory: @escaping (EventLoop) throws -> InitializerType)
         where InitializerType.SelectorType.DefaultOperationDelegateType.InvocationReportingType == SmokeServerInvocationReporting<TraceContextType>,
@@ -74,6 +76,16 @@ public extension SmokeHTTP1Server {
               
               // initialize the logger after instatiating the initializer
               let logger = Logger.init(label: "application.initialization")
+        
+              let eventLoopProvider: SmokeHTTP1Server.EventLoopProvider
+              // if the initializer is indicating to create new threads for the server
+              // just use the created eventLoopGroup
+              if case .spawnNewThreads = initalizer.eventLoopProvider {
+                  eventLoopProvider = .use(eventLoopGroup)
+              } else {
+                  // use what the initializer says
+                  eventLoopProvider = initalizer.eventLoopProvider
+              }
               
               let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
                   handlerSelector: initalizer.handlerSelector,
@@ -83,7 +95,7 @@ public extension SmokeHTTP1Server {
                                                     port: initalizer.port,
                                                     invocationStrategy: initalizer.invocationStrategy,
                                                     defaultLogger: initalizer.defaultLogger,
-                                                    eventLoopProvider: initalizer.eventLoopProvider,
+                                                    eventLoopProvider: eventLoopProvider,
                                                     shutdownOnSignal: initalizer.shutdownOnSignal)
               do {
                   try server.start()
@@ -124,6 +136,16 @@ public extension SmokeHTTP1Server {
               
               // initialize the logger after instatiating the initializer
               let logger = Logger.init(label: "application.initialization")
+        
+              let eventLoopProvider: SmokeHTTP1Server.EventLoopProvider
+              // if the initializer is indicating to create new threads for the server
+              // just use the created eventLoopGroup
+              if case .spawnNewThreads = initalizer.eventLoopProvider {
+                  eventLoopProvider = .use(eventLoopGroup)
+              } else {
+                  // use what the initializer says
+                  eventLoopProvider = initalizer.eventLoopProvider
+              }
               
               let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
                   handlerSelector: initalizer.handlerSelector,
@@ -133,7 +155,7 @@ public extension SmokeHTTP1Server {
                                                     port: initalizer.port,
                                                     invocationStrategy: initalizer.invocationStrategy,
                                                     defaultLogger: initalizer.defaultLogger,
-                                                    eventLoopProvider: initalizer.eventLoopProvider,
+                                                    eventLoopProvider: eventLoopProvider,
                                                     shutdownOnSignal: initalizer.shutdownOnSignal)
               do {
                   try server.start()

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting+withInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting+withInvocationTraceContext.swift
@@ -18,18 +18,22 @@ import Foundation
 import Logging
 import SmokeOperations
 import SmokeHTTPClient
+import NIO
 
 public struct DelegatedInvocationReporting<TraceContextType: InvocationTraceContext>: HTTPClientCoreInvocationReporting {
     public let logger: Logger
     public var internalRequestId: String
     public var traceContext: TraceContextType
+    public var eventLoop: EventLoop?
     
     public init(logger: Logger,
                 internalRequestId: String,
-                traceContext: TraceContextType) {
+                traceContext: TraceContextType,
+                eventLoop: EventLoop? = nil) {
         self.logger = logger
         self.internalRequestId = internalRequestId
         self.traceContext = traceContext
+        self.eventLoop = eventLoop
     }
 }
 
@@ -42,7 +46,8 @@ public extension SmokeServerInvocationReporting {
         traceContext: TraceContextType) -> DelegatedInvocationReporting<TraceContextType> {
         return DelegatedInvocationReporting(logger: self.logger,
                                             internalRequestId: self.internalRequestId,
-                                            traceContext: traceContext)
+                                            traceContext: traceContext,
+                                            eventLoop: self.eventLoop)
         
     }
 }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Use the same event loop group for the initializer and server if the server is creating new threads anyway. Pass the event loop to the DelegatedInvocationReporting instance.

Combines with https://github.com/amzn/smoke-http/pull/74 to pass through the eventloop used by an incoming smoke-framework request to any smoke-http based clients.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
