### PR TITLE
Report request latency, broken down into time for service calls, retry waits.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "0a8dddbe15cd72f7bb5e47951fb7c1eb0836dfc2",
-          "version": "1.2.2"
+          "revision": "a72c5adce3986ff6b5092ae0464a8f2675087860",
+          "version": "1.2.3"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "f9ec5d8c2023452bbd371e827725499f99cd5fd8",
-          "version": "2.2.1"
+          "revision": "6619fe6f8e56a85d9a7d9481c27afb2dc5688459",
+          "version": "2.7.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
-          "version": "1.4.0"
+          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
+          "version": "1.4.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "c3e2359c55cd8b47207ab7363b77c9c398a95294",
-          "version": "2.23.0"
+          "revision": "6d3ca7e54e06a69d0f2612c2ce8bb8b7319085a4",
+          "version": "2.26.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "e5b5d191a80667a14827bfeb0ae4a511f7677942",
-          "version": "1.7.0"
+          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
+          "version": "1.8.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "eb102ad32add8638410e37a69bc815ea11379813",
-          "version": "2.10.0"
+          "revision": "4c933e955b8797f5a5a90bd2a0fb411fdb11bb94",
+          "version": "2.10.3"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "bb56586c4cab9a79dce6ec4738baddb5802c5de7",
-          "version": "1.9.0"
+          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
+          "version": "1.9.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.7.0"),
     ],
     targets: [
         .target(
@@ -62,6 +62,7 @@ let package = Package(
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "NIOExtras", package: "swift-nio-extras"),
+                .product(name: "SmokeHTTPClient", package: "smoke-http"),
                 .target(name: "SmokeInvocation"),
             ]),
         .target(

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.7.0"),
     ],
     targets: [
         .target(
@@ -56,7 +56,8 @@ let package = Package(
             dependencies: ["Logging"]),
         .target(
             name: "SmokeHTTP1",
-            dependencies: ["NIO", "NIOHTTP1", "NIOFoundationCompat", "NIOExtras", "Logging", "SmokeInvocation"]),
+            dependencies: ["NIO", "NIOHTTP1", "NIOFoundationCompat", "NIOExtras", "Logging",
+                           "SmokeHTTPClient", "SmokeInvocation"]),
         .target(
             name: "SmokeOperations",
             dependencies: ["Logging", "Metrics", "SmokeInvocation"]),

--- a/Sources/SmokeHTTP1/ChannelHTTP1ResponseHandler.swift
+++ b/Sources/SmokeHTTP1/ChannelHTTP1ResponseHandler.swift
@@ -40,4 +40,39 @@ public protocol ChannelHTTP1ResponseHandler {
          wrapOutboundOut: @escaping (_ value: HTTPServerResponsePart) -> NIOAny,
          onComplete: @escaping () -> ())
     
+    /**
+     Initializer.
+     
+     - Parameters:
+         - requestHead: the head of the request that this handler will respond to.
+         - keepAliveStatus: if the request should be kept alive.
+         - context: the `ChannelHandlerContext` associated with the response.
+         - smokeInwardsRequestContext: the context of the inwards request.
+         - wrapOutboundOut: helper function to prepare a `HTTPServerResponsePart` for transmission on the channel.
+         - onComplete: to be called when the response has been sent on the channel.
+     */
+    init(requestHead: HTTPRequestHead,
+         keepAliveStatus: KeepAliveStatus,
+         context: ChannelHandlerContext,
+         smokeInwardsRequestContext: SmokeInwardsRequestContext?,
+         wrapOutboundOut: @escaping (_ value: HTTPServerResponsePart) -> NIOAny,
+         onComplete: @escaping () -> ())
+    
+}
+
+public extension ChannelHTTP1ResponseHandler {
+    // The function is being added as a non-breaking change, so add a default implementation that delegates to the existing
+    // function that must be implemented.
+    init(requestHead: HTTPRequestHead,
+         keepAliveStatus: KeepAliveStatus,
+         context: ChannelHandlerContext,
+         smokeInwardsRequestContext: SmokeInwardsRequestContext?,
+         wrapOutboundOut: @escaping (_ value: HTTPServerResponsePart) -> NIOAny,
+         onComplete: @escaping () -> ()) {
+        self.init(requestHead: requestHead,
+                  keepAliveStatus: keepAliveStatus,
+                  context: context,
+                  wrapOutboundOut: wrapOutboundOut,
+                  onComplete: onComplete)
+    }
 }

--- a/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
@@ -272,11 +272,14 @@ class HTTP1ChannelInboundHandler<HTTP1RequestHandlerType: HTTP1RequestHandler>: 
             self.state.responseFullSent()
         }
         
+        let smokeInwardsRequestContext = StandardSmokeInwardsRequestContext(requestStart: Date())
+        
         // create a response handler for this request
         let responseHandler = HTTP1RequestHandlerType.ResponseHandlerType(
             requestHead: requestHead,
             keepAliveStatus: pendingResponse.keepAliveStatus,
             context: context,
+            smokeInwardsRequestContext: smokeInwardsRequestContext,
             wrapOutboundOut: wrapOutboundOut,
             onComplete: onComplete)
     
@@ -289,6 +292,7 @@ class HTTP1ChannelInboundHandler<HTTP1RequestHandlerType: HTTP1RequestHandler>: 
                               invocationStrategy: invocationStrategy,
                               requestLogger: logger,
                               eventLoop: context.eventLoop,
+                              outwardsRequestAggregator: smokeInwardsRequestContext,
                               internalRequestId: pendingResponse.internalRequestId)
     }
     

--- a/Sources/SmokeHTTP1/HTTP1RequestHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1RequestHandler.swift
@@ -20,6 +20,7 @@ import NIO
 import NIOHTTP1
 import Logging
 import SmokeInvocation
+import SmokeHTTPClient
 
 /**
  Protocol that specifies a handler for a HttpRequest.
@@ -55,6 +56,23 @@ public protocol HTTP1RequestHandler {
      */
     func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                 invocationStrategy: InvocationStrategy, requestLogger: Logger, eventLoop: EventLoop?, internalRequestId: String)
+    
+    /**
+     Handles an incoming request.
+ 
+     - Parameters:
+         - requestHead: the parameters specified in the head of the HTTP request.
+         - body: the body of the request, if any.
+         - responseHandler: a handler that can be used to respond to the request.
+         - invocationStrategy: the invocationStrategy to use for this request.
+         - requestLogger: the logger to use for this request.
+         - eventLoop: the event loop used for this request.
+         - outwardsRequestAggregator: the outwards request aggregator to use.
+         - internalRequestId: the internal identifier for this request.
+     */
+    func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
+                invocationStrategy: InvocationStrategy, requestLogger: Logger, eventLoop: EventLoop?,
+                outwardsRequestAggregator: OutwardsRequestAggregator?, internalRequestId: String)
 }
 
 public extension HTTP1RequestHandler {
@@ -62,6 +80,15 @@ public extension HTTP1RequestHandler {
     // function that must be implemented.
     func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                 invocationStrategy: InvocationStrategy, requestLogger: Logger, eventLoop: EventLoop?, internalRequestId: String) {
+        handle(requestHead: requestHead, body: body, responseHandler: responseHandler, invocationStrategy: invocationStrategy,
+               requestLogger: requestLogger, internalRequestId: internalRequestId)
+    }
+    
+    // The function is being added as a non-breaking change, so add a default implementation that delegates to the existing
+    // function that must be implemented.
+    func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
+                invocationStrategy: InvocationStrategy, requestLogger: Logger, eventLoop: EventLoop?,
+                outwardsRequestAggregator: OutwardsRequestAggregator?, internalRequestId: String) {
         handle(requestHead: requestHead, body: body, responseHandler: responseHandler, invocationStrategy: invocationStrategy,
                requestLogger: requestLogger, internalRequestId: internalRequestId)
     }

--- a/Sources/SmokeHTTP1/SmokeInwardsRequestContext.swift
+++ b/Sources/SmokeHTTP1/SmokeInwardsRequestContext.swift
@@ -1,0 +1,57 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeInwardsRequestContext.swift
+// SmokeHTTP1
+//
+
+import Foundation
+import SmokeHTTPClient
+
+public protocol SmokeInwardsRequestContext {
+    var requestStart: Date { get }
+    
+    var retriableOutputRequestRecords: [RetriableOutputRequestRecord] { get }
+    
+    var retryAttemptRecords: [RetryAttemptRecord] { get }
+}
+
+internal class StandardSmokeInwardsRequestContext: SmokeInwardsRequestContext, OutwardsRequestAggregator {
+    let requestStart: Date
+    private(set) var retriableOutputRequestRecords: [RetriableOutputRequestRecord]
+    private(set) var retryAttemptRecords: [RetryAttemptRecord]
+    
+    init(requestStart: Date) {
+        self.requestStart = requestStart
+        self.retriableOutputRequestRecords = []
+        self.retryAttemptRecords = []
+    }
+    
+    func recordOutwardsRequest(outputRequestRecord: OutputRequestRecord) {
+        let retriableOutwardsRequest = SmokeRetriableOutputRequestRecord(outputRequests: [outputRequestRecord])
+        
+        self.retriableOutputRequestRecords.append(retriableOutwardsRequest)
+    }
+    
+    func recordRetryAttempt(retryAttemptRecord: RetryAttemptRecord) {
+        self.retryAttemptRecords.append(retryAttemptRecord)
+    }
+    
+    func recordRetriableOutwardsRequest(retriableOutwardsRequest: RetriableOutputRequestRecord) {
+        self.retriableOutputRequestRecords.append(retriableOutwardsRequest)
+    }
+}
+
+struct SmokeRetriableOutputRequestRecord: RetriableOutputRequestRecord {
+    var outputRequests: [OutputRequestRecord]
+}

--- a/Sources/SmokeOperations/SmokeOperationReporting.swift
+++ b/Sources/SmokeOperations/SmokeOperationReporting.swift
@@ -26,6 +26,9 @@ public struct SmokeOperationReporting {
     public let failure5XXCounter: Metrics.Counter?
     public let failure4XXCounter: Metrics.Counter?
     public let latencyTimer: Metrics.Timer?
+    public let serviceLatencyTimer: Metrics.Timer?
+    public let outwardsServiceCallLatencySumTimer: Metrics.Timer?
+    public let outwardsServiceCallRetryWaitSumTimer: Metrics.Timer?
     
     private let namespaceDimension = "Namespace"
     private let operationNameDimension = "Operation Name"
@@ -35,6 +38,9 @@ public struct SmokeOperationReporting {
     private let failure5XXCountMetric = "failure5XXCount"
     private let failure4XXCountMetric = "failure4XXCount"
     private let latencyTimeMetric = "latencyTime"
+    private let serviceLatencyTimeMetric = "serviceLatencyTime"
+    private let outwardsServiceCallLatencySumMetric = "outwardsServiceCallLatencySum"
+    private let outwardsServiceCallRetryWaitSumMetric = "outwardsServiceCallRetryWaitSum"
     
     public init<OperationIdentifer: OperationIdentity>(serverName: String, request: RequestType<OperationIdentifer>,
                                                        configuration: SmokeReportingConfiguration<OperationIdentifer>) {
@@ -78,6 +84,36 @@ public struct SmokeOperationReporting {
                                          dimensions: latencyTimeDimensions)
         } else {
             latencyTimer = nil
+        }
+        
+        if configuration.reportServiceLatencyForRequest(request) {
+            let serviceLatencyTimeDimensions = [(namespaceDimension, serverName),
+                                                (operationNameDimension, operationName),
+                                                (metricNameDimension, serviceLatencyTimeMetric)]
+            serviceLatencyTimer = Metrics.Timer(label: "\(serverName).\(operationName).\(serviceLatencyTimeMetric)",
+                                                dimensions: serviceLatencyTimeDimensions)
+        } else {
+            serviceLatencyTimer = nil
+        }
+        
+        if configuration.reportOutwardsServiceCallLatencySumForRequest(request) {
+            let serviceLatencyTimeDimensions = [(namespaceDimension, serverName),
+                                                (operationNameDimension, operationName),
+                                                (metricNameDimension, outwardsServiceCallLatencySumMetric)]
+            outwardsServiceCallLatencySumTimer = Metrics.Timer(label: "\(serverName).\(operationName).\(outwardsServiceCallLatencySumMetric)",
+                                                               dimensions: serviceLatencyTimeDimensions)
+        } else {
+            outwardsServiceCallLatencySumTimer = nil
+        }
+        
+        if configuration.reportOutwardsServiceCallRetryWaitLatencySumForRequest(request) {
+            let serviceLatencyTimeDimensions = [(namespaceDimension, serverName),
+                                                (operationNameDimension, operationName),
+                                                (metricNameDimension, outwardsServiceCallRetryWaitSumMetric)]
+            outwardsServiceCallRetryWaitSumTimer = Metrics.Timer(label: "\(serverName).\(operationName).\(outwardsServiceCallRetryWaitSumMetric)",
+                                                                 dimensions: serviceLatencyTimeDimensions)
+        } else {
+            outwardsServiceCallRetryWaitSumTimer = nil
         }
     }
 }

--- a/Sources/SmokeOperations/SmokeReportingConfiguration.swift
+++ b/Sources/SmokeOperations/SmokeReportingConfiguration.swift
@@ -59,6 +59,14 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
             self.errorDeterminingOperation = errorDeterminingOperation
             self.matchingOperations = matchingOperations
         }
+        
+        public static var all: MatchingRequests {
+            return .init(matchingOperations: .all)
+        }
+        
+        public static var none: MatchingRequests {
+            return .init(matchingOperations: .none)
+        }
     }
     
     private let successCounterMatchingRequests: MatchingRequests
@@ -66,14 +74,25 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
     private let failure4XXCounterMatchingRequests: MatchingRequests
     private let latencyTimerMatchingRequests: MatchingRequests
     
+    // these are added as a non-breaking change, so by default they are not enabled
+    private let serviceLatencyTimerMatchingRequests: MatchingRequests
+    private let outwardServiceCallLatencySumTimerMatchingRequests: MatchingRequests
+    private let outwardServiceCallRetryWaitSumTimerMatchingRequests: MatchingRequests
+    
     public init(successCounterMatchingRequests: MatchingRequests,
                 failure5XXCounterMatchingRequests: MatchingRequests,
                 failure4XXCounterMatchingRequests: MatchingRequests,
-                latencyTimerMatchingRequests: MatchingRequests) {
+                latencyTimerMatchingRequests: MatchingRequests,
+                serviceLatencyTimerMatchingRequests: MatchingRequests = .none,
+                outwardServiceCallLatencyTimerMatchingRequests: MatchingRequests = .none,
+                outwardServiceCallRetryWaitTimerMatchingRequests: MatchingRequests = .none) {
         self.successCounterMatchingRequests = successCounterMatchingRequests
         self.failure5XXCounterMatchingRequests = failure5XXCounterMatchingRequests
         self.failure4XXCounterMatchingRequests = failure4XXCounterMatchingRequests
         self.latencyTimerMatchingRequests = latencyTimerMatchingRequests
+        self.serviceLatencyTimerMatchingRequests = serviceLatencyTimerMatchingRequests
+        self.outwardServiceCallLatencySumTimerMatchingRequests = outwardServiceCallLatencyTimerMatchingRequests
+        self.outwardServiceCallRetryWaitSumTimerMatchingRequests = outwardServiceCallRetryWaitTimerMatchingRequests
     }
     
     public init(matchingRequests: MatchingRequests = MatchingRequests()) {
@@ -81,6 +100,9 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
         self.failure5XXCounterMatchingRequests = matchingRequests
         self.failure4XXCounterMatchingRequests = matchingRequests
         self.latencyTimerMatchingRequests = matchingRequests
+        self.serviceLatencyTimerMatchingRequests = .none
+        self.outwardServiceCallLatencySumTimerMatchingRequests = .none
+        self.outwardServiceCallRetryWaitSumTimerMatchingRequests = .none
     }
     
     public func reportSuccessForRequest(_ request: RequestType<OperationIdentifer>) -> Bool {
@@ -97,6 +119,18 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
     
     public func reportLatencyForRequest(_ request: RequestType<OperationIdentifer>) -> Bool {
         return isMatchingRequest(request, matchingRequests: latencyTimerMatchingRequests)
+    }
+    
+    public func reportServiceLatencyForRequest(_ request: RequestType<OperationIdentifer>) -> Bool {
+        return isMatchingRequest(request, matchingRequests: serviceLatencyTimerMatchingRequests)
+    }
+    
+    public func reportOutwardsServiceCallLatencySumForRequest(_ request: RequestType<OperationIdentifer>) -> Bool {
+        return isMatchingRequest(request, matchingRequests: outwardServiceCallLatencySumTimerMatchingRequests)
+    }
+    
+    public func reportOutwardsServiceCallRetryWaitLatencySumForRequest(_ request: RequestType<OperationIdentifer>) -> Bool {
+        return isMatchingRequest(request, matchingRequests: outwardServiceCallRetryWaitSumTimerMatchingRequests)
     }
     
     private func isMatchingRequest(_ request: RequestType<OperationIdentifer>, matchingRequests: MatchingRequests) -> Bool {

--- a/Sources/SmokeOperationsHTTP1Server/HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeOperationsHTTP1Server/HTTP1RequestInvocationContext.swift
@@ -11,18 +11,58 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  HTTP1RequestTraceContext.swift
+//  HTTP1RequestInvocationContext.swift
 //  SmokeOperationsHTTP1Server
 //
 
 import Foundation
 import Logging
 import NIOHTTP1
+import Metrics
 
 public protocol HTTP1RequestInvocationContext {
     
     var logger: Logger { get }
     
+    var successCounter: Metrics.Counter? { get }
+    var failure5XXCounter: Metrics.Counter? { get }
+    var failure4XXCounter: Metrics.Counter? { get }
+    var latencyTimer: Metrics.Timer? { get }
+    var serviceLatencyTimer: Metrics.Timer? { get }
+    var outwardsServiceCallLatencySumTimer: Metrics.Timer? { get }
+    var outwardsServiceCallRetryWaitSumTimer: Metrics.Timer? { get }
+    
     func handleInwardsRequestComplete(httpHeaders: inout HTTPHeaders, status: HTTPResponseStatus,
                                       body: (contentType: String, data: Data)?)
+}
+
+public extension HTTP1RequestInvocationContext {
+    // The properties is being added as a non-breaking change, so add a default implementation.
+    var successCounter: Metrics.Counter? {
+        return nil
+    }
+    
+    var failure5XXCounter: Metrics.Counter? {
+        return nil
+    }
+    
+    var failure4XXCounter: Metrics.Counter? {
+        return nil
+    }
+    
+    var latencyTimer: Metrics.Timer? {
+        return nil
+    }
+    
+    var serviceLatencyTimer: Metrics.Timer? {
+        return nil
+    }
+    
+    var outwardsServiceCallLatencySumTimer: Metrics.Timer? {
+        return nil
+    }
+    
+    var outwardsServiceCallRetryWaitSumTimer: Metrics.Timer? {
+        return nil
+    }
 }

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerHTTP1RequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerHTTP1RequestHandler.swift
@@ -24,6 +24,7 @@ import SmokeHTTP1
 import ShapeCoding
 import Logging
 import SmokeInvocation
+import SmokeHTTPClient
 
 /**
  Implementation of the HttpRequestHandler protocol that handles an
@@ -68,11 +69,13 @@ struct OperationServerHTTP1RequestHandler<SelectorType, TraceContextType>: HTTP1
     public func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                        invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String) {
         handle(requestHead: requestHead, body: body, responseHandler: responseHandler,
-               invocationStrategy: invocationStrategy, requestLogger: requestLogger, eventLoop: nil, internalRequestId: internalRequestId)
+               invocationStrategy: invocationStrategy, requestLogger: requestLogger, eventLoop: nil,
+               outwardsRequestAggregator: nil, internalRequestId: internalRequestId)
     }
 
     public func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
-                       invocationStrategy: InvocationStrategy, requestLogger: Logger, eventLoop: EventLoop?, internalRequestId: String) {
+                       invocationStrategy: InvocationStrategy, requestLogger: Logger, eventLoop: EventLoop?,
+                       outwardsRequestAggregator: OutwardsRequestAggregator?, internalRequestId: String) {
         
         let traceContext = TraceContextType(requestHead: requestHead, bodyData: body)
         var decoratedRequestLogger: Logger = requestLogger
@@ -81,7 +84,9 @@ struct OperationServerHTTP1RequestHandler<SelectorType, TraceContextType>: HTTP1
         
         func invocationReportingProvider(logger: Logger) -> SmokeServerInvocationReporting<TraceContextType> {
             return SmokeServerInvocationReporting(logger: logger,
-                                                  internalRequestId: internalRequestId, traceContext: traceContext, eventLoop: eventLoop)
+                                                  internalRequestId: internalRequestId, traceContext: traceContext,
+                                                  eventLoop: eventLoop,
+                                                  outwardsRequestAggregator: outwardsRequestAggregator)
         }
         
         // let it be handled

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
@@ -19,15 +19,44 @@ import SmokeHTTP1
 import SmokeOperations
 import Logging
 import NIOHTTP1
+import Metrics
 
 extension SmokeInvocationContext: HTTP1RequestInvocationContext where
         InvocationReportingType: InvocationReportingWithTraceContext,
         InvocationReportingType.TraceContextType.RequestHeadType == HTTPRequestHead,
         InvocationReportingType.TraceContextType.ResponseHeadersType == HTTPHeaders,
-        InvocationReportingType.TraceContextType.ResponseStatusType == HTTPResponseStatus {
+    InvocationReportingType.TraceContextType.ResponseStatusType == HTTPResponseStatus {
     
     public var logger: Logger {
         return self.invocationReporting.logger
+    }
+    
+    public var successCounter: Metrics.Counter? {
+        return self.requestReporting.successCounter
+    }
+    
+    public var failure5XXCounter: Metrics.Counter? {
+        return self.requestReporting.failure5XXCounter
+    }
+    
+    public var failure4XXCounter: Metrics.Counter? {
+        return self.requestReporting.failure4XXCounter
+    }
+    
+    public var latencyTimer: Metrics.Timer? {
+        return self.requestReporting.latencyTimer
+    }
+    
+    public var serviceLatencyTimer: Metrics.Timer? {
+        return self.requestReporting.serviceLatencyTimer
+    }
+    
+    public var outwardsServiceCallLatencySumTimer: Metrics.Timer? {
+        return self.requestReporting.outwardsServiceCallLatencySumTimer
+    }
+    
+    public var outwardsServiceCallRetryWaitSumTimer: Metrics.Timer? {
+        return self.requestReporting.outwardsServiceCallRetryWaitSumTimer
     }
     
     public func handleInwardsRequestComplete(httpHeaders: inout HTTPHeaders, status: HTTPResponseStatus, body: (contentType: String, data: Data)?) {

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting+withInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting+withInvocationTraceContext.swift
@@ -25,15 +25,18 @@ public struct DelegatedInvocationReporting<TraceContextType: InvocationTraceCont
     public var internalRequestId: String
     public var traceContext: TraceContextType
     public var eventLoop: EventLoop?
+    public var outwardsRequestAggregator: OutwardsRequestAggregator?
     
     public init(logger: Logger,
                 internalRequestId: String,
                 traceContext: TraceContextType,
-                eventLoop: EventLoop? = nil) {
+                eventLoop: EventLoop? = nil,
+                outwardsRequestAggregator: OutwardsRequestAggregator? = nil) {
         self.logger = logger
         self.internalRequestId = internalRequestId
         self.traceContext = traceContext
         self.eventLoop = eventLoop
+        self.outwardsRequestAggregator = outwardsRequestAggregator
     }
 }
 
@@ -47,7 +50,8 @@ public extension SmokeServerInvocationReporting {
         return DelegatedInvocationReporting(logger: self.logger,
                                             internalRequestId: self.internalRequestId,
                                             traceContext: traceContext,
-                                            eventLoop: self.eventLoop)
+                                            eventLoop: self.eventLoop,
+                                            outwardsRequestAggregator: self.outwardsRequestAggregator)
         
     }
 }

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting.swift
@@ -19,6 +19,7 @@ import Foundation
 import SmokeOperations
 import Logging
 import NIO
+import SmokeHTTPClient
 
 public protocol InvocationReportingWithTraceContext: InvocationReporting {
     associatedtype TraceContextType: OperationTraceContext
@@ -32,13 +33,16 @@ public protocol InvocationReportingWithTraceContext: InvocationReporting {
 public struct SmokeServerInvocationReporting<TraceContextType: OperationTraceContext>: InvocationReportingWithTraceContext {
     public let logger: Logger
     public let eventLoop: EventLoop?
+    public let outwardsRequestAggregator: OutwardsRequestAggregator?
     public let internalRequestId: String
     public let traceContext: TraceContextType
     
-    public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType, eventLoop: EventLoop? = nil) {
+    public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType,
+                eventLoop: EventLoop? = nil, outwardsRequestAggregator: OutwardsRequestAggregator? = nil) {
         self.logger = logger
         self.eventLoop = eventLoop
         self.internalRequestId = internalRequestId
         self.traceContext = traceContext
+        self.outwardsRequestAggregator = outwardsRequestAggregator
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add three additional metrics to potentially be emitted

```
let serviceLatencyTimer: Metrics.Timer
let outwardsServiceCallLatencySumTimer: Metrics.Timer
let outwardsServiceCallRetryWaitSumTimer: Metrics.Timer
```

Create a `SmokeInwardsRequestContext` protocol to aggregate all the request data and emit metrics at the end of the request.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
