### PR TITLE
Add addHandlerForOperationProvider functions to the selector.

### DIFF
--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingFromProviderWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingFromProviderWithInputNoOutput.swift
@@ -1,0 +1,146 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+blockingFromProviderWithInputNoOutput.swift
+// SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) throws -> Void)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation) {
+        func operation(input: InputType, context: ContextType) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) throws -> Void)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation,
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation,
+                               operationDelegate: operationDelegate)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol, ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) throws -> Void)),
+            allowedErrors: [(ErrorType, Int)]) {
+        func operation(input: InputType, context: ContextType) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
+            ErrorType: ErrorIdentifiableByDescription,
+            OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) throws -> Void)),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingFromProviderWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+blockingFromProviderWithInputWithOutput.swift
@@ -1,0 +1,154 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+blockingFromProviderWithInputWithOutput.swift
+// SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) throws -> OutputType)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation,
+            outputLocation: OperationOutputHTTPLocation) {
+        func operation(input: InputType, context: ContextType) throws -> OutputType {
+            let innerOperation = operationProvider(context)
+            return try innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation,
+                               outputLocation: outputLocation)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) throws -> OutputType)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation,
+            outputLocation: OperationOutputHTTPLocation,
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType) throws -> OutputType {
+            let innerOperation = operationProvider(context)
+            return try innerOperation(input)
+        }
+            
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation,
+                               outputLocation: outputLocation,
+                               operationDelegate: operationDelegate)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
+            OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) throws -> OutputType)),
+            allowedErrors: [(ErrorType, Int)]) {
+        func operation(input: InputType, context: ContextType) throws -> OutputType {
+            let innerOperation = operationProvider(context)
+            return try innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
+            OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) throws -> OutputType)),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType) throws -> OutputType {
+            let innerOperation = operationProvider(context)
+            return try innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingFromProviderWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingFromProviderWithInputNoOutput.swift
@@ -1,0 +1,147 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+nonblockingFromProviderWithInputNoOutput.swift
+// SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType, @escaping (Swift.Error?) -> ()) throws -> ())),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation) {
+        func operation(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input, completion)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+            OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType, @escaping (Swift.Error?) -> ()) throws -> ())),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation,
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input, completion)
+        }
+            
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation,
+                               operationDelegate: operationDelegate)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
+            ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType, @escaping (Swift.Error?) -> ()) throws -> ())),
+            allowedErrors: [(ErrorType, Int)]) {
+        func operation(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input, completion)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
+            ErrorType: ErrorIdentifiableByDescription,
+            OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType, @escaping (Swift.Error?) -> ()) throws -> ())),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType, completion: @escaping (Swift.Error?) -> ()) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input, completion)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               operationDelegate: operationDelegate)
+    }
+}

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingFromProviderWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+nonblockingFromProviderWithInputWithOutput.swift
@@ -1,0 +1,157 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  SmokeHTTP1HandlerSelector+nonblockingFromProviderWithInputWithOutput.swift
+//  SmokeOperationsHTTP1
+//
+
+import Foundation
+import SmokeOperations
+import NIOHTTP1
+import Logging
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType, @escaping
+                                                             (Result<OutputType, Swift.Error>) -> Void) throws -> Void)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation,
+            outputLocation: OperationOutputHTTPLocation) {
+        func operation(input: InputType, context: ContextType, completion: @escaping (Result<OutputType, Swift.Error>) -> Void) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input, completion)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation,
+                               outputLocation: outputLocation)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType, @escaping
+                                                             (Result<OutputType, Swift.Error>) -> Void) throws -> Void)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation,
+            outputLocation: OperationOutputHTTPLocation,
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType, completion: @escaping (Result<OutputType, Swift.Error>) -> Void) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input, completion)
+        }
+            
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation,
+                               outputLocation: outputLocation,
+                               operationDelegate: operationDelegate)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType, @escaping
+                                                             (Result<OutputType, Swift.Error>) -> Void) throws -> Void)),
+            allowedErrors: [(ErrorType, Int)]) {
+        func operation(input: InputType, context: ContextType, completion: @escaping (Result<OutputType, Swift.Error>) -> Void) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input, completion)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol, OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType, @escaping
+                                                             (Result<OutputType, Swift.Error>) -> Void) throws -> Void)),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType, completion: @escaping (Result<OutputType, Swift.Error>) -> Void) throws {
+            let innerOperation = operationProvider(context)
+            try innerOperation(input, completion)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               operationDelegate: operationDelegate)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adds new `addHandlerForOperationProvider` functions to `SmokeHTTP1HandlerSelector`.  These provide an `operationProvider` rather than the `operation` of the existing `addHandlerForOperation` functions.

Rather than providing the `operation` function directly, the `operationProvider` is a function that, given a `ContextType` instance, will produce an `operation` function similar to the existing `addHandlerForOperation` functions (minus the context type input parameter).

Conveniently, this function-that-produces-a-function is compatible with the static members that instance functions produce on their types. This will allow operation handlers to be instance functions on the context type which might be more convenient and avoids polluting the global namespace. The existing `addHandlerForOperation` functions remain, allowing existing operation handlers to continue unchanged.

**Example of an operational handler within an extension of the context type-**

_Previously_
```
public func handleCreateCustomerPut(
        input: PersistenceExampleModel.CreateCustomerRequest,
        context: PersistenceExampleOperationsContext) throws -> PersistenceExampleModel.CreateCustomerPut200Response {
    ...
    
    try context.dynamodbTable.insertItem(newDatabaseItem).wait()
    
    ...
}
```
https://github.com/amzn/smoke-framework-examples/blob/main/PersistenceExampleService/Sources/PersistenceExampleOperations/CreateCustomerPut.swift

_Possible with this change_
```
extension PersistenceExampleOperationsContext {
    public func handleCreateCustomerPut(input: PersistenceExampleModel.CreateCustomerRequest) throws
    -> PersistenceExampleModel.CreateCustomerPut200Response {
        ...
        
        try self.dynamodbTable.insertItem(newDatabaseItem).wait()
        
        ...
    }
}
``` 
https://github.com/amzn/smoke-framework-examples/blob/operation_handlers_on_context/PersistenceExampleService/Sources/PersistenceExampleOperations/CreateCustomerPut.swift

**Example of the generated code adding handlers to the selector.**
```
public func addOperations<SelectorType: SmokeHTTP1HandlerSelector>(selector: inout SelectorType)
    where SelectorType.ContextType == PersistenceExampleOperationsContext,
    SelectorType.OperationIdentifer == PersistenceExampleModelOperations {

    ...
    
    let allowedErrorsForCreateCustomerPut: [(PersistenceExampleErrorTypes, Int)] = [(.unknownResource, 404)]
    selector.addHandlerForOperationProvider(.createCustomerPut, httpMethod: .PUT,
                                            operationProvider: PersistenceExampleOperationsContext.handleCreateCustomerPut,
                                            allowedErrors: allowedErrorsForCreateCustomerPut)
    
    ...
}
```
https://github.com/amzn/smoke-framework-examples/blob/operation_handlers_on_context/PersistenceExampleService/Sources/PersistenceExampleOperationsHTTP1/PersistenceExampleOperationsHanderSelector.swift


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
