### PR TITLE
Add initial async/await support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,13 @@ matrix:
       services: docker
       env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-5.4-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
+    # Verify against nightly of Swift mainline
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+
     # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
     - os: linux
       dist: xenial

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,14 @@ let package = Package(
             name: "SmokeOperations",
             targets: ["SmokeOperations"]),
         .library(
+            name: "_SmokeOperationsConcurrency",
+            targets: ["_SmokeOperationsConcurrency"]),
+        .library(
             name: "SmokeOperationsHTTP1",
             targets: ["SmokeOperationsHTTP1"]),
+        .library(
+            name: "_SmokeOperationsHTTP1Concurrency",
+            targets: ["_SmokeOperationsHTTP1Concurrency"]),
         .library(
             name: "SmokeOperationsHTTP1Server",
             targets: ["SmokeOperationsHTTP1Server"]),
@@ -72,12 +78,20 @@ let package = Package(
                 .target(name: "SmokeInvocation"),
             ]),
         .target(
+            name: "_SmokeOperationsConcurrency", dependencies: [
+                .target(name: "SmokeOperations"),
+            ]),
+        .target(
             name: "SmokeOperationsHTTP1", dependencies: [
                 .target(name: "SmokeOperations"),
                 .product(name: "QueryCoding", package: "smoke-http"),
                 .product(name: "HTTPPathCoding", package: "smoke-http"),
                 .product(name: "HTTPHeadersCoding", package: "smoke-http"),
                 .product(name: "SmokeHTTPClient", package: "smoke-http"),
+            ]),
+        .target(
+            name: "_SmokeOperationsHTTP1Concurrency", dependencies: [
+                .target(name: "SmokeOperationsHTTP1"),
             ]),
         .target(
             name: "SmokeOperationsHTTP1Server", dependencies: [

--- a/Sources/SmokeOperations/OperationHandler.swift
+++ b/Sources/SmokeOperations/OperationHandler.swift
@@ -134,7 +134,7 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
         reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
         inputHandler: @escaping OperationResultValidatableInputFunction<InputType>,
         inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
-        operationDelegate: OperationDelegateType)
+        operationDelegate: OperationDelegateType, ignoreInvocationStrategy: Bool = false)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
     InvocationReportingType == OperationDelegateType.InvocationReportingType,
     ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
@@ -207,12 +207,20 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
             // continue the execution of the request according to the `invocationStrategy`
             // To avoid retaining the original body `Data` object, `body` should not be referenced in this
             // invocation.
-            invocationStrategy.invoke {
+            if ignoreInvocationStrategy {
                 inputDecodeResult.handle(
                     requestHead: requestHead,
                     context: context,
                     responseHandler: responseHandler,
                     operationDelegate: operationDelegate)
+            } else {
+                invocationStrategy.invoke {
+                    inputDecodeResult.handle(
+                        requestHead: requestHead,
+                        context: context,
+                        responseHandler: responseHandler,
+                        operationDelegate: operationDelegate)
+                }
             }
         }
         

--- a/Sources/_SmokeOperationsConcurrency/OperationHandler+withContextInputNoOutput.swift
+++ b/Sources/_SmokeOperationsConcurrency/OperationHandler+withContextInputNoOutput.swift
@@ -1,0 +1,87 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OperationHandler+withContextInputNoOutput.swift
+// _SmokeOperationsConcurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import Logging
+import SmokeOperations
+import _Concurrency
+
+public extension OperationHandler {
+    /**
+       Initializer for async operation handler that has input returns
+       a result with an empty body.
+     
+     - Parameters:
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it so that if it
+         * returns, the responseHandler is called to indicate success. If the provided operation
+         * throws an error, the responseHandler is called with that error.
+         */
+        func wrappedInputHandler(input: InputType, requestHead: RequestHeadType, context: ContextType,
+                                 responseHandler: ResponseHandlerType,
+                                 invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+            Task.runDetached {
+                let handlerResult: NoOutputOperationHandlerResult<ErrorType>
+                do {
+                    try await operation(input, context, invocationContext.invocationReporting)
+                    
+                    handlerResult = .success
+                } catch let smokeReturnableError as SmokeReturnableError {
+                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+                } catch SmokeOperationsError.validationError(reason: let reason) {
+                    handlerResult = .validationError(reason)
+                } catch {
+                    handlerResult = .internalServerError(error)
+                }
+                
+                OperationHandler.handleNoOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate,
+                  ignoreInvocationStrategy: true)
+    }
+}
+
+#endif

--- a/Sources/_SmokeOperationsConcurrency/OperationHandler+withContextInputWithOutput.swift
+++ b/Sources/_SmokeOperationsConcurrency/OperationHandler+withContextInputWithOutput.swift
@@ -1,0 +1,91 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OperationHandler+withContextInputWithOutput.swift
+// _SmokeOperationsConcurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import Logging
+import SmokeOperations
+import _Concurrency
+
+public extension OperationHandler {
+    /**
+      Initializer for async operation handler that has input returns
+      a result body.
+     
+     - Parameters:
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping (InputType, ContextType, InvocationReportingType) async throws -> OutputType,
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeInvocationContext<InvocationReportingType>) -> Void),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it so that if it
+         * returns, the responseHandler is called with the result. If the provided operation
+         * throws an error, the responseHandler is called with that error.
+         */
+        func wrappedInputHandler(input: InputType, requestHead: RequestHeadType, context: ContextType,
+                                 responseHandler: OperationDelegateType.ResponseHandlerType,
+                                 invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+            Task.runDetached {
+                let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
+                do {
+                    let output = try await operation(input, context, invocationContext.invocationReporting)
+                    
+                    handlerResult = .success(output)
+                } catch let smokeReturnableError as SmokeReturnableError {
+                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+                } catch SmokeOperationsError.validationError(reason: let reason) {
+                    handlerResult = .validationError(reason)
+                } catch {
+                    handlerResult = .internalServerError(error)
+                }
+                
+                OperationHandler.handleWithOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    outputHandler: outputHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate,
+                  ignoreInvocationStrategy: true)
+    }
+}
+
+#endif

--- a/Sources/_SmokeOperationsConcurrency/OperationHandler+withInputNoOutput.swift
+++ b/Sources/_SmokeOperationsConcurrency/OperationHandler+withInputNoOutput.swift
@@ -1,0 +1,93 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OperationHandler+withInputNoOutput.swift
+// _SmokeOperationsConcurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import Logging
+import SmokeOperations
+import _Concurrency
+
+public extension OperationHandler {
+    /**
+       Initializer for async operation handler that has input returns
+       a result with an empty body.
+     
+     - Parameters:
+        - serverName: the name of the server this operation is part of.
+        - operationIdentifer: the identifer for the operation being handled.
+        - reportingConfiguration: the configuration for how operations on this server should be reported on.
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer,
+            reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType) async throws -> ()),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it so that if it
+         * returns, the responseHandler is called to indicate success. If the provided operation
+         * throws an error, the responseHandler is called with that error.
+         */
+        func wrappedInputHandler(input: InputType, requestHead: RequestHeadType, context: ContextType,
+                                 responseHandler: ResponseHandlerType,
+                                 invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+            Task.runDetached {
+                let handlerResult: NoOutputOperationHandlerResult<ErrorType>
+                do {
+                    try await operation(input, context)
+                    
+                    handlerResult = .success
+                } catch let smokeReturnableError as SmokeReturnableError {
+                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+                } catch SmokeOperationsError.validationError(reason: let reason) {
+                    handlerResult = .validationError(reason)
+                } catch {
+                    handlerResult = .internalServerError(error)
+                }
+                
+                OperationHandler.handleNoOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName,
+                  operationIdentifer: operationIdentifer,
+                  reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate,
+                  ignoreInvocationStrategy: true)
+    }
+}
+
+#endif

--- a/Sources/_SmokeOperationsConcurrency/OperationHandler+withInputWithOutput.swift
+++ b/Sources/_SmokeOperationsConcurrency/OperationHandler+withInputWithOutput.swift
@@ -1,0 +1,97 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OperationHandler+withInputWithOutput.swift
+// _SmokeOperationsConcurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import Logging
+import SmokeOperations
+import _Concurrency
+
+public extension OperationHandler {
+    /**
+      Initializer for async operation handler that has input returns
+      a result body.
+     
+     - Parameters:
+        - serverName: the name of the server this operation is part of.
+        - operationIdentifer: the identifer for the operation being handled.
+        - reportingConfiguration: the configuration for how operations on this server should be reported on.
+        - inputProvider: function that obtains the input from the request.
+        - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: optionally an operation-specific delegate to use when
+          handling the operation.
+     */
+    init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: OperationDelegate>(
+            serverName: String, operationIdentifer: OperationIdentifer,
+            reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping (InputType, ContextType) async throws -> OutputType,
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeInvocationContext<InvocationReportingType>) -> Void),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where RequestHeadType == OperationDelegateType.RequestHeadType,
+    InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        /**
+         * The wrapped input handler takes the provided operation handler and wraps it so that if it
+         * returns, the responseHandler is called with the result. If the provided operation
+         * throws an error, the responseHandler is called with that error.
+         */
+        func wrappedInputHandler (input: InputType, requestHead: RequestHeadType, context: ContextType,
+                                  responseHandler: OperationDelegateType.ResponseHandlerType,
+                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+            Task.runDetached {
+                let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
+                do {
+                    let output = try await operation(input, context)
+                    
+                    handlerResult = .success(output)
+                } catch let smokeReturnableError as SmokeReturnableError {
+                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+                } catch SmokeOperationsError.validationError(reason: let reason) {
+                    handlerResult = .validationError(reason)
+                } catch {
+                    handlerResult = .internalServerError(error)
+                }
+                
+                OperationHandler.handleWithOutputOperationHandlerResult(
+                    handlerResult: handlerResult,
+                    operationDelegate: operationDelegate,
+                    requestHead: requestHead,
+                    responseHandler: responseHandler,
+                    outputHandler: outputHandler,
+                    invocationContext: invocationContext)
+            }
+        }
+        
+        self.init(serverName: serverName,
+                  operationIdentifer: operationIdentifer,
+                  reportingConfiguration: reportingConfiguration,
+                  inputHandler: wrappedInputHandler,
+                  inputProvider: inputProvider,
+                  operationDelegate: operationDelegate,
+                  ignoreInvocationStrategy: true)
+    }
+}
+
+#endif

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
@@ -1,0 +1,152 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
+// _SmokeOperationsHTTP1Concurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import SmokeOperations
+import _SmokeOperationsConcurrency
+import NIOHTTP1
+import Logging
+import SmokeOperationsHTTP1
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) async throws -> Void)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation) {
+        func operation(input: InputType, context: ContextType) async throws {
+            let innerOperation = operationProvider(context)
+            try await innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) async throws -> Void)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation,
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType) async throws {
+            let innerOperation = operationProvider(context)
+            try await innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation,
+                               operationDelegate: operationDelegate)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol, ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) async throws -> Void)),
+            allowedErrors: [(ErrorType, Int)]) {
+        func operation(input: InputType, context: ContextType) async throws {
+            let innerOperation = operationProvider(context)
+            try await innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
+            ErrorType: ErrorIdentifiableByDescription,
+            OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) async throws -> Void)),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType) async throws {
+            let innerOperation = operationProvider(context)
+            try await innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               operationDelegate: operationDelegate)
+    }
+}
+
+#endif

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
@@ -1,0 +1,160 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
+// _SmokeOperationsHTTP1Concurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import SmokeOperations
+import _SmokeOperationsConcurrency
+import NIOHTTP1
+import Logging
+import SmokeOperationsHTTP1
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) async throws -> OutputType)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation,
+            outputLocation: OperationOutputHTTPLocation) {
+        func operation(input: InputType, context: ContextType) async throws -> OutputType {
+            let innerOperation = operationProvider(context)
+            return try await innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation,
+                               outputLocation: outputLocation)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) async throws -> OutputType)),
+            allowedErrors: [(ErrorType, Int)],
+            inputLocation: OperationInputHTTPLocation,
+            outputLocation: OperationOutputHTTPLocation,
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType) async throws -> OutputType {
+            let innerOperation = operationProvider(context)
+            return try await innerOperation(input)
+        }
+            
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors,
+                               inputLocation: inputLocation,
+                               outputLocation: outputLocation,
+                               operationDelegate: operationDelegate)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
+            OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) async throws -> OutputType)),
+            allowedErrors: [(ErrorType, Int)]) {
+        func operation(input: InputType, context: ContextType) async throws -> OutputType {
+            let innerOperation = operationProvider(context)
+            return try await innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operationProvider: when given a `ContextType` instance will provide the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
+            OutputType: ValidatableOperationHTTP1OutputProtocol,
+            ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+            _ operationIdentifer: OperationIdentifer,
+            httpMethod: HTTPMethod,
+            operationProvider: @escaping ((ContextType) -> ((InputType) async throws -> OutputType)),
+            allowedErrors: [(ErrorType, Int)],
+            operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        func operation(input: InputType, context: ContextType) async throws -> OutputType {
+            let innerOperation = operationProvider(context)
+            return try await innerOperation(input)
+        }
+        
+        addHandlerForOperation(operationIdentifer,
+                               httpMethod: httpMethod,
+                               operation: operation,
+                               allowedErrors: allowedErrors)
+    }
+}
+
+#endif

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
@@ -1,0 +1,165 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
+// _SmokeOperationsHTTP1Concurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import SmokeOperations
+import _SmokeOperationsConcurrency
+import NIOHTTP1
+import Logging
+import SmokeOperationsHTTP1
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}
+
+#endif

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
@@ -1,0 +1,197 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
+// _SmokeOperationsHTTP1Concurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import SmokeOperations
+import _SmokeOperationsConcurrency
+import NIOHTTP1
+import Logging
+import SmokeOperationsHTTP1
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
+                           output: OutputType,
+                           responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
+                           invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+            delegateToUse.handleResponseForOperation(requestHead: requestHead,
+                                                     location: outputLocation,
+                                                     output: output,
+                                                     responseHandler: responseHandler,
+                                                     invocationContext: invocationContext)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            outputHandler: outputHandler,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
+                               output: OutputType,
+                               responseHandler: OperationDelegateType.ResponseHandlerType,
+                               invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+                operationDelegate.handleResponseForOperation(requestHead: requestHead,
+                                                             location: outputLocation,
+                                                             output: output,
+                                                             responseHandler: responseHandler,
+                                                             invocationContext: invocationContext)
+            }
+            
+            let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                outputHandler: outputHandler,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        OutputType: ValidatableOperationHTTP1OutputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: defaultOperationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        OutputType: ValidatableOperationHTTP1OutputProtocol,
+        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: operationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}
+
+#endif

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
@@ -1,0 +1,169 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+withInputNoOutput.swift
+// _SmokeOperationsHTTP1Concurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import SmokeOperations
+import _SmokeOperationsConcurrency
+import NIOHTTP1
+import Logging
+import SmokeOperationsHTTP1
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) async throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) async throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            let handler = OperationHandler(
+                serverName: serverName, operationIdentifer: operationIdentifer,
+                reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) async throws -> ()),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) async throws -> ()),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}
+
+#endif

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
@@ -1,0 +1,201 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SmokeHTTP1HandlerSelector+withInputWithOutput.swift
+// _SmokeOperationsHTTP1Concurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import SmokeOperations
+import _SmokeOperationsConcurrency
+import NIOHTTP1
+import Logging
+import SmokeOperationsHTTP1
+
+public extension SmokeHTTP1HandlerSelector {
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) async throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation) {
+        
+        // don't capture self
+        let delegateToUse = defaultOperationDelegate
+        func inputProvider(requestHead: DefaultOperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+            return try delegateToUse.getInputForOperation(
+                requestHead: requestHead,
+                body: body,
+                location: inputLocation)
+        }
+        
+        func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
+                           output: OutputType,
+                           responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
+                           invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+            delegateToUse.handleResponseForOperation(requestHead: requestHead,
+                                                     location: outputLocation,
+                                                     output: output,
+                                                     responseHandler: responseHandler,
+                                                     invocationContext: invocationContext)
+        }
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: inputProvider,
+            operation: operation,
+            outputHandler: outputHandler,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - inputLocation: the location in the incoming http request to decode the input from.
+        - outputLocation: the location in the outgoing http response to place the encoded output.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
+        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) async throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        inputLocation: OperationInputHTTPLocation,
+        outputLocation: OperationOutputHTTPLocation,
+        operationDelegate: OperationDelegateType)
+        where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+        DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+        DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+            
+            func inputProvider(requestHead: OperationDelegateType.RequestHeadType, body: Data?) throws -> InputType {
+                return try operationDelegate.getInputForOperation(
+                    requestHead: requestHead,
+                    body: body,
+                    location: inputLocation)
+            }
+            
+            func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
+                               output: OutputType,
+                               responseHandler: OperationDelegateType.ResponseHandlerType,
+                               invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+                operationDelegate.handleResponseForOperation(requestHead: requestHead,
+                                                             location: outputLocation,
+                                                             output: output,
+                                                             responseHandler: responseHandler,
+                                                             invocationContext: invocationContext)
+            }
+            
+            let handler = OperationHandler(
+                serverName: serverName, operationIdentifer: operationIdentifer,
+                reportingConfiguration: reportingConfiguration,
+                inputProvider: inputProvider,
+                operation: operation,
+                outputHandler: outputHandler,
+                allowedErrors: allowedErrors,
+                operationDelegate: operationDelegate)
+            
+            addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        OutputType: ValidatableOperationHTTP1OutputProtocol,
+        ErrorType: ErrorIdentifiableByDescription>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) async throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)]) {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: defaultOperationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: defaultOperationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: defaultOperationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+    
+    /**
+     Adds a handler for the specified uri and http method.
+ 
+     - Parameters:
+        - uri: The uri to add the handler for.
+        - operation: the handler method for the operation.
+        - allowedErrors: the errors that can be serialized as responses
+          from the operation and their error codes.
+        - operationDelegate: an operation-specific delegate to use when
+          handling the operation.
+     */
+    mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
+        OutputType: ValidatableOperationHTTP1OutputProtocol,
+        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        _ operationIdentifer: OperationIdentifer,
+        httpMethod: HTTPMethod,
+        operation: @escaping ((InputType, ContextType) async throws -> OutputType),
+        allowedErrors: [(ErrorType, Int)],
+        operationDelegate: OperationDelegateType)
+    where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
+    DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
+    DefaultOperationDelegateType.ResponseHandlerType == OperationDelegateType.ResponseHandlerType {
+        
+        let handler = OperationHandler(
+            serverName: serverName, operationIdentifer: operationIdentifer,
+            reportingConfiguration: reportingConfiguration,
+            inputProvider: operationDelegate.getInputForOperation,
+            operation: operation,
+            outputHandler: operationDelegate.handleResponseForOperation,
+            allowedErrors: allowedErrors,
+            operationDelegate: operationDelegate)
+        
+        addHandlerForOperation(operationIdentifer, httpMethod: httpMethod, handler: handler)
+    }
+}
+
+#endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Following the approach of swift-nio, add these to underscored packages.
2. Add `OperationHandler` initialiser variants that accept async functions and run the operation in a detached task.
3. Add `addHandlerForOperation*` variants that accept async functions and use the new `OperationHandler` initialiser variants.
4. Add a flag in the primary `OperationHandler` initialiser to bypass the Invocation Strategy. The Invocation Strategy will be replaced in the async world by Executors; the Invocation Strategy will have no effect on where an async function is run.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
