### PR TITLE
Add missing SmokeHTTP1 dependency from SmokeOperationsHTTP1Tests.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -113,6 +113,7 @@ let package = Package(
         .testTarget(
             name: "SmokeOperationsHTTP1Tests", dependencies: [
                 .target(name: "SmokeOperationsHTTP1"),
+                .target(name: "SmokeHTTP1"),
             ]),
     ],
     swiftLanguageVersions: [.v5]


### PR DESCRIPTION
*Issue #, if available:* #77

*Description of changes:* Identified by @Davidde94 as causing a non-deterministic compilation failure. Added dependency as suggested.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
