### PR TITLE
Clean up api availability on Apple platforms.

### DIFF
--- a/Sources/_SmokeOperationsConcurrency/OperationHandler+withContextInputWithOutput.swift
+++ b/Sources/_SmokeOperationsConcurrency/OperationHandler+withContextInputWithOutput.swift
@@ -15,7 +15,7 @@
 // _SmokeOperationsConcurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import Logging
@@ -36,7 +36,7 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
@@ -57,8 +57,7 @@ public extension OperationHandler {
         func wrappedInputHandler(input: InputType, requestHead: RequestHeadType, context: ContextType,
                                  responseHandler: OperationDelegateType.ResponseHandlerType,
                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
-#if os(Linux) || os(Windows)
-            Task.detached {
+            Task {
                 let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
                 do {
                     let output = try await operation(input, context, invocationContext.invocationReporting)
@@ -80,31 +79,6 @@ public extension OperationHandler {
                     outputHandler: outputHandler,
                     invocationContext: invocationContext)
             }
-#else
-            // TODO: Workaround for XCode 13 Beta 1; remove when concurrency spelling has stablized
-            asyncDetached {
-                let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
-                do {
-                    let output = try await operation(input, context, invocationContext.invocationReporting)
-                    
-                    handlerResult = .success(output)
-                } catch let smokeReturnableError as SmokeReturnableError {
-                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
-                } catch SmokeOperationsError.validationError(reason: let reason) {
-                    handlerResult = .validationError(reason)
-                } catch {
-                    handlerResult = .internalServerError(error)
-                }
-                
-                OperationHandler.handleWithOutputOperationHandlerResult(
-                    handlerResult: handlerResult,
-                    operationDelegate: operationDelegate,
-                    requestHead: requestHead,
-                    responseHandler: responseHandler,
-                    outputHandler: outputHandler,
-                    invocationContext: invocationContext)
-            }
-#endif
         }
         
         self.init(serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,

--- a/Sources/_SmokeOperationsConcurrency/OperationHandler+withInputNoOutput.swift
+++ b/Sources/_SmokeOperationsConcurrency/OperationHandler+withInputNoOutput.swift
@@ -15,7 +15,7 @@
 // _SmokeOperationsConcurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import Logging
@@ -38,7 +38,7 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer,
             reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
@@ -58,8 +58,7 @@ public extension OperationHandler {
         func wrappedInputHandler(input: InputType, requestHead: RequestHeadType, context: ContextType,
                                  responseHandler: ResponseHandlerType,
                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
-#if os(Linux) || os(Windows)
-            Task.detached {
+            Task {
                 let handlerResult: NoOutputOperationHandlerResult<ErrorType>
                 do {
                     try await operation(input, context)
@@ -80,30 +79,6 @@ public extension OperationHandler {
                     responseHandler: responseHandler,
                     invocationContext: invocationContext)
             }
-#else
-            // TODO: Workaround for XCode 13 Beta 1; remove when concurrency spelling has stablized
-            asyncDetached {
-                let handlerResult: NoOutputOperationHandlerResult<ErrorType>
-                do {
-                    try await operation(input, context)
-                    
-                    handlerResult = .success
-                } catch let smokeReturnableError as SmokeReturnableError {
-                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
-                } catch SmokeOperationsError.validationError(reason: let reason) {
-                    handlerResult = .validationError(reason)
-                } catch {
-                    handlerResult = .internalServerError(error)
-                }
-                
-                OperationHandler.handleNoOutputOperationHandlerResult(
-                    handlerResult: handlerResult,
-                    operationDelegate: operationDelegate,
-                    requestHead: requestHead,
-                    responseHandler: responseHandler,
-                    invocationContext: invocationContext)
-            }
-#endif
         }
         
         self.init(serverName: serverName,

--- a/Sources/_SmokeOperationsConcurrency/OperationHandler+withInputWithOutput.swift
+++ b/Sources/_SmokeOperationsConcurrency/OperationHandler+withInputWithOutput.swift
@@ -15,7 +15,7 @@
 // _SmokeOperationsConcurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import Logging
@@ -39,7 +39,7 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer,
@@ -61,8 +61,7 @@ public extension OperationHandler {
         func wrappedInputHandler (input: InputType, requestHead: RequestHeadType, context: ContextType,
                                   responseHandler: OperationDelegateType.ResponseHandlerType,
                                   invocationContext: SmokeInvocationContext<InvocationReportingType>) {
-#if os(Linux) || os(Windows)
-            Task.detached {
+            Task {
                 let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
                 do {
                     let output = try await operation(input, context)
@@ -84,31 +83,6 @@ public extension OperationHandler {
                     outputHandler: outputHandler,
                     invocationContext: invocationContext)
             }
-#else
-            // TODO: Workaround for XCode 13 Beta 1; remove when concurrency spelling has stablized
-            asyncDetached {
-                let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
-                do {
-                    let output = try await operation(input, context)
-                    
-                    handlerResult = .success(output)
-                } catch let smokeReturnableError as SmokeReturnableError {
-                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
-                } catch SmokeOperationsError.validationError(reason: let reason) {
-                    handlerResult = .validationError(reason)
-                } catch {
-                    handlerResult = .internalServerError(error)
-                }
-                
-                OperationHandler.handleWithOutputOperationHandlerResult(
-                    handlerResult: handlerResult,
-                    operationDelegate: operationDelegate,
-                    requestHead: requestHead,
-                    responseHandler: responseHandler,
-                    outputHandler: outputHandler,
-                    invocationContext: invocationContext)
-            }
-#endif
         }
         
         self.init(serverName: serverName,

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
@@ -15,7 +15,7 @@
 // _SmokeOperationsHTTP1Concurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import SmokeOperations
@@ -36,7 +36,7 @@ public extension SmokeHTTP1HandlerSelector {
           from the operation and their error codes.
         - inputLocation: the location in the incoming http request to decode the input from.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
             _ operationIdentifer: OperationIdentifer,
             httpMethod: HTTPMethod,
@@ -68,7 +68,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
             _ operationIdentifer: OperationIdentifer,
@@ -103,7 +103,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol, ErrorType: ErrorIdentifiableByDescription>(
             _ operationIdentifer: OperationIdentifer,
             httpMethod: HTTPMethod,
@@ -132,7 +132,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
             ErrorType: ErrorIdentifiableByDescription,
             OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
@@ -15,7 +15,7 @@
 // _SmokeOperationsHTTP1Concurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import SmokeOperations
@@ -37,7 +37,7 @@ public extension SmokeHTTP1HandlerSelector {
         - inputLocation: the location in the incoming http request to decode the input from.
         - outputLocation: the location in the outgoing http response to place the encoded output.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
             ErrorType: ErrorIdentifiableByDescription>(
             _ operationIdentifer: OperationIdentifer,
@@ -73,7 +73,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
             _ operationIdentifer: OperationIdentifer,
@@ -110,7 +110,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
             OutputType: ValidatableOperationHTTP1OutputProtocol,
             ErrorType: ErrorIdentifiableByDescription>(
@@ -141,7 +141,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
             OutputType: ValidatableOperationHTTP1OutputProtocol,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
@@ -15,7 +15,7 @@
 // _SmokeOperationsHTTP1Concurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import SmokeOperations
@@ -36,7 +36,7 @@ public extension SmokeHTTP1HandlerSelector {
           from the operation and their error codes.
         - inputLocation: the location in the incoming http request to decode the input from.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
@@ -76,7 +76,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
@@ -116,7 +116,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
@@ -146,7 +146,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
@@ -15,7 +15,7 @@
 // _SmokeOperationsHTTP1Concurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import SmokeOperations
@@ -37,7 +37,7 @@ public extension SmokeHTTP1HandlerSelector {
         - inputLocation: the location in the incoming http request to decode the input from.
         - outputLocation: the location in the outgoing http response to place the encoded output.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
@@ -92,7 +92,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
@@ -145,7 +145,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
@@ -177,7 +177,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
@@ -15,7 +15,7 @@
 // _SmokeOperationsHTTP1Concurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import SmokeOperations
@@ -36,7 +36,7 @@ public extension SmokeHTTP1HandlerSelector {
           from the operation and their error codes.
         - inputLocation: the location in the incoming http request to decode the input from.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
@@ -77,7 +77,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
@@ -118,7 +118,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
@@ -149,7 +149,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
@@ -15,7 +15,7 @@
 // _SmokeOperationsHTTP1Concurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import SmokeOperations
@@ -37,7 +37,7 @@ public extension SmokeHTTP1HandlerSelector {
         - inputLocation: the location in the incoming http request to decode the input from.
         - outputLocation: the location in the outgoing http response to place the encoded output.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
@@ -93,7 +93,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
@@ -147,7 +147,7 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
@@ -180,7 +180,7 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
1. Clean up api availability on Apple platforms. 
2. Remove XCode Beta 1 workaround.
3. Change Task.detached to Task so the child task can retain priority, task-local values and the actor[1].

[1] https://developer.apple.com/videos/play/wwdc2021/10134?time=1578


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
