### PR TITLE
Final async await support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,28 @@ matrix:
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+
+    - os: linux
+      dist: bionic
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.4.3-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
       
     - os: linux
       dist: bionic
@@ -33,13 +39,6 @@ matrix:
       sudo: required
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.2.5-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
-
-    # Verify next version of Swift (5.5)
-    - os: linux
-      dist: bionic
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-5.5-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
     # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
     - os: linux

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "8ccba7328d178ac05a1a9803cf3f2c6660d2f826",
-          "version": "1.3.0"
+          "revision": "8fa7f082b155ea325bcf7b2dbffaf81d4eea1ae4",
+          "version": "1.5.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "8411ef45e7b683ea80b568bb30c3c53b532dcbed",
-          "version": "2.8.4"
+          "revision": "530dd118b9603a7027634c8c133a736f9684831e",
+          "version": "2.8.8"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "e382458581b05839a571c578e90060fff499f101",
-          "version": "2.1.1"
+          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
+          "version": "2.2.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "d161bf658780b209c185994528e7e24376cf7283",
-          "version": "2.29.0"
+          "revision": "fb48bdd8279799f655da5f8b4e0a21430eca6012",
+          "version": "2.32.3"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
-          "version": "1.8.0"
+          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
+          "version": "1.10.2"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "6363cdf6d2fb863e82434f3c4618f4e896e37569",
-          "version": "2.13.1"
+          "revision": "044f90dfa0a7015446b40f5e578b06343ae1affe",
+          "version": "2.16.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "657537c2cf1845f8d5201ecc4e48f21f21841128",
-          "version": "1.10.0"
+          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
+          "version": "1.11.3"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://travis-ci.com/amzn/smoke-framework.svg?branch=master" alt="Build - Master Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4-orange.svg?style=flat" alt="Swift 5.2, 5.3 and 5.4 Tested">
+<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.2, 5.3, 5.4 and 5.5 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import Logging
-import SmokeOperations
 
 public extension OperationHandler {
     /**

--- a/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
@@ -11,38 +11,34 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-// OperationHandler+withContextInputWithOutput.swift
-// _SmokeOperationsConcurrency
+// OperationHandler+withContextInputNoOutput.swift
+// SmokeOperations
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import Logging
 import SmokeOperations
-import _Concurrency
 
 public extension OperationHandler {
     /**
-      Initializer for async operation handler that has input returns
-      a result body.
+       Initializer for async operation handler that has input returns
+       a result with an empty body.
      
      - Parameters:
         - inputProvider: function that obtains the input from the request.
         - operation: the handler method for the operation.
-        - outputHandler: function that completes the response with the provided output.
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
-        OperationDelegateType: OperationDelegate>(
+    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
-            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
-            operation: @escaping (InputType, ContextType, InvocationReportingType) async throws -> OutputType,
-            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeInvocationContext<InvocationReportingType>) -> Void),
+            inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
@@ -51,18 +47,18 @@ public extension OperationHandler {
         
         /**
          * The wrapped input handler takes the provided operation handler and wraps it so that if it
-         * returns, the responseHandler is called with the result. If the provided operation
+         * returns, the responseHandler is called to indicate success. If the provided operation
          * throws an error, the responseHandler is called with that error.
          */
         func wrappedInputHandler(input: InputType, requestHead: RequestHeadType, context: ContextType,
-                                 responseHandler: OperationDelegateType.ResponseHandlerType,
+                                 responseHandler: ResponseHandlerType,
                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
             Task {
-                let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
+                let handlerResult: NoOutputOperationHandlerResult<ErrorType>
                 do {
-                    let output = try await operation(input, context, invocationContext.invocationReporting)
+                    try await operation(input, context, invocationContext.invocationReporting)
                     
-                    handlerResult = .success(output)
+                    handlerResult = .success
                 } catch let smokeReturnableError as SmokeReturnableError {
                     handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
                 } catch SmokeOperationsError.validationError(reason: let reason) {
@@ -71,12 +67,11 @@ public extension OperationHandler {
                     handlerResult = .internalServerError(error)
                 }
                 
-                OperationHandler.handleWithOutputOperationHandlerResult(
+                OperationHandler.handleNoOutputOperationHandlerResult(
                     handlerResult: handlerResult,
                     operationDelegate: operationDelegate,
                     requestHead: requestHead,
                     responseHandler: responseHandler,
-                    outputHandler: outputHandler,
                     invocationContext: invocationContext)
             }
         }

--- a/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
@@ -11,35 +11,37 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-// OperationHandler+withContextInputNoOutput.swift
-// _SmokeOperationsConcurrency
+// OperationHandler+withContextInputWithOutput.swift
+// SmokeOperations
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import Logging
 import SmokeOperations
-import _Concurrency
 
 public extension OperationHandler {
     /**
-       Initializer for async operation handler that has input returns
-       a result with an empty body.
+      Initializer for async operation handler that has input returns
+      a result body.
      
      - Parameters:
         - inputProvider: function that obtains the input from the request.
         - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+    init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
-            inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
-            operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping (InputType, ContextType, InvocationReportingType) async throws -> OutputType,
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeInvocationContext<InvocationReportingType>) -> Void),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
@@ -48,18 +50,18 @@ public extension OperationHandler {
         
         /**
          * The wrapped input handler takes the provided operation handler and wraps it so that if it
-         * returns, the responseHandler is called to indicate success. If the provided operation
+         * returns, the responseHandler is called with the result. If the provided operation
          * throws an error, the responseHandler is called with that error.
          */
         func wrappedInputHandler(input: InputType, requestHead: RequestHeadType, context: ContextType,
-                                 responseHandler: ResponseHandlerType,
+                                 responseHandler: OperationDelegateType.ResponseHandlerType,
                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
             Task {
-                let handlerResult: NoOutputOperationHandlerResult<ErrorType>
+                let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
                 do {
-                    try await operation(input, context, invocationContext.invocationReporting)
+                    let output = try await operation(input, context, invocationContext.invocationReporting)
                     
-                    handlerResult = .success
+                    handlerResult = .success(output)
                 } catch let smokeReturnableError as SmokeReturnableError {
                     handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
                 } catch SmokeOperationsError.validationError(reason: let reason) {
@@ -68,11 +70,12 @@ public extension OperationHandler {
                     handlerResult = .internalServerError(error)
                 }
                 
-                OperationHandler.handleNoOutputOperationHandlerResult(
+                OperationHandler.handleWithOutputOperationHandlerResult(
                     handlerResult: handlerResult,
                     operationDelegate: operationDelegate,
                     requestHead: requestHead,
                     responseHandler: responseHandler,
+                    outputHandler: outputHandler,
                     invocationContext: invocationContext)
             }
         }

--- a/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import Logging
-import SmokeOperations
 
 public extension OperationHandler {
     /**

--- a/Sources/SmokeOperations/OperationHandler+withInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withInputNoOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import Logging
-import SmokeOperations
 
 public extension OperationHandler {
     /**

--- a/Sources/SmokeOperations/OperationHandler+withInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withInputWithOutput.swift
@@ -11,21 +11,20 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-// OperationHandler+withInputNoOutput.swift
-// _SmokeOperationsConcurrency
+// OperationHandler+withInputWithOutput.swift
+// SmokeOperations
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import Logging
 import SmokeOperations
-import _Concurrency
 
 public extension OperationHandler {
     /**
-       Initializer for async operation handler that has input returns
-       a result with an empty body.
+      Initializer for async operation handler that has input returns
+      a result body.
      
      - Parameters:
         - serverName: the name of the server this operation is part of.
@@ -33,17 +32,20 @@ public extension OperationHandler {
         - reportingConfiguration: the configuration for how operations on this server should be reported on.
         - inputProvider: function that obtains the input from the request.
         - operation: the handler method for the operation.
+        - outputHandler: function that completes the response with the provided output.
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
+    init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer,
             reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
-            inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,
-            operation: @escaping ((InputType, ContextType) async throws -> ()),
+            inputProvider: @escaping (RequestHeadType, Data?) throws -> InputType,
+            operation: @escaping (InputType, ContextType) async throws -> OutputType,
+            outputHandler: @escaping ((RequestHeadType, OutputType, ResponseHandlerType, SmokeInvocationContext<InvocationReportingType>) -> Void),
             allowedErrors: [(ErrorType, Int)],
             operationDelegate: OperationDelegateType)
     where RequestHeadType == OperationDelegateType.RequestHeadType,
@@ -52,18 +54,18 @@ public extension OperationHandler {
         
         /**
          * The wrapped input handler takes the provided operation handler and wraps it so that if it
-         * returns, the responseHandler is called to indicate success. If the provided operation
+         * returns, the responseHandler is called with the result. If the provided operation
          * throws an error, the responseHandler is called with that error.
          */
-        func wrappedInputHandler(input: InputType, requestHead: RequestHeadType, context: ContextType,
-                                 responseHandler: ResponseHandlerType,
-                                 invocationContext: SmokeInvocationContext<InvocationReportingType>) {
+        func wrappedInputHandler (input: InputType, requestHead: RequestHeadType, context: ContextType,
+                                  responseHandler: OperationDelegateType.ResponseHandlerType,
+                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
             Task {
-                let handlerResult: NoOutputOperationHandlerResult<ErrorType>
+                let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
                 do {
-                    try await operation(input, context)
+                    let output = try await operation(input, context)
                     
-                    handlerResult = .success
+                    handlerResult = .success(output)
                 } catch let smokeReturnableError as SmokeReturnableError {
                     handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
                 } catch SmokeOperationsError.validationError(reason: let reason) {
@@ -72,11 +74,12 @@ public extension OperationHandler {
                     handlerResult = .internalServerError(error)
                 }
                 
-                OperationHandler.handleNoOutputOperationHandlerResult(
+                OperationHandler.handleWithOutputOperationHandlerResult(
                     handlerResult: handlerResult,
                     operationDelegate: operationDelegate,
                     requestHead: requestHead,
                     responseHandler: responseHandler,
+                    outputHandler: outputHandler,
                     invocationContext: invocationContext)
             }
         }

--- a/Sources/SmokeOperations/OperationHandler+withInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withInputWithOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import Logging
-import SmokeOperations
 
 public extension OperationHandler {
     /**

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
@@ -12,10 +12,10 @@
 // permissions and limitations under the License.
 //
 // SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
-// _SmokeOperationsHTTP1Concurrency
+// SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import SmokeOperations
-import _SmokeOperationsConcurrency
 import NIOHTTP1
 import Logging
 import SmokeOperationsHTTP1

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
@@ -21,7 +21,6 @@ import Foundation
 import SmokeOperations
 import NIOHTTP1
 import Logging
-import SmokeOperationsHTTP1
 
 public extension SmokeHTTP1HandlerSelector {
     /**

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
@@ -12,10 +12,10 @@
 // permissions and limitations under the License.
 //
 // SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
-// _SmokeOperationsHTTP1Concurrency
+// SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import SmokeOperations
-import _SmokeOperationsConcurrency
 import NIOHTTP1
 import Logging
 import SmokeOperationsHTTP1

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
@@ -21,7 +21,6 @@ import Foundation
 import SmokeOperations
 import NIOHTTP1
 import Logging
-import SmokeOperationsHTTP1
 
 public extension SmokeHTTP1HandlerSelector {
     /**

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
@@ -11,11 +11,11 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-// SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
-// _SmokeOperationsHTTP1Concurrency
+// SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
+// SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations
@@ -35,17 +35,14 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
         - inputLocation: the location in the incoming http request to decode the input from.
-        - outputLocation: the location in the outgoing http response to place the encoded output.
      */
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
-        ErrorType: ErrorIdentifiableByDescription>(
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> OutputType),
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
         allowedErrors: [(ErrorType, Int)],
-        inputLocation: OperationInputHTTPLocation,
-        outputLocation: OperationOutputHTTPLocation) {
+        inputLocation: OperationInputHTTPLocation) {
         
         // don't capture self
         let delegateToUse = defaultOperationDelegate
@@ -56,22 +53,10 @@ public extension SmokeHTTP1HandlerSelector {
                 location: inputLocation)
         }
         
-        func outputHandler(requestHead: DefaultOperationDelegateType.RequestHeadType,
-                           output: OutputType,
-                           responseHandler: DefaultOperationDelegateType.ResponseHandlerType,
-                           invocationContext: SmokeInvocationContext<InvocationReportingType>) {
-            delegateToUse.handleResponseForOperation(requestHead: requestHead,
-                                                     location: outputLocation,
-                                                     output: output,
-                                                     responseHandler: responseHandler,
-                                                     invocationContext: invocationContext)
-        }
-        
         let handler = OperationHandler(
             serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
             inputProvider: inputProvider,
             operation: operation,
-            outputHandler: outputHandler,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
@@ -88,19 +73,17 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
         - inputLocation: the location in the incoming http request to decode the input from.
-        - outputLocation: the location in the outgoing http response to place the encoded output.
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
-        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+    mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> OutputType),
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         inputLocation: OperationInputHTTPLocation,
-        outputLocation: OperationOutputHTTPLocation,
         operationDelegate: OperationDelegateType)
         where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
         DefaultOperationDelegateType.InvocationReportingType == OperationDelegateType.InvocationReportingType,
@@ -113,22 +96,10 @@ public extension SmokeHTTP1HandlerSelector {
                     location: inputLocation)
             }
             
-            func outputHandler(requestHead: OperationDelegateType.RequestHeadType,
-                               output: OutputType,
-                               responseHandler: OperationDelegateType.ResponseHandlerType,
-                               invocationContext: SmokeInvocationContext<InvocationReportingType>) {
-                operationDelegate.handleResponseForOperation(requestHead: requestHead,
-                                                             location: outputLocation,
-                                                             output: output,
-                                                             responseHandler: responseHandler,
-                                                             invocationContext: invocationContext)
-            }
-            
             let handler = OperationHandler(
             serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
                 inputProvider: inputProvider,
                 operation: operation,
-                outputHandler: outputHandler,
                 allowedErrors: allowedErrors,
                 operationDelegate: operationDelegate)
             
@@ -147,18 +118,16 @@ public extension SmokeHTTP1HandlerSelector {
      */
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
-        OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> OutputType),
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
         allowedErrors: [(ErrorType, Int)]) {
         
         let handler = OperationHandler(
             serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
             inputProvider: defaultOperationDelegate.getInputForOperation,
             operation: operation,
-            outputHandler: defaultOperationDelegate.handleResponseForOperation,
             allowedErrors: allowedErrors,
             operationDelegate: defaultOperationDelegate)
         
@@ -179,11 +148,11 @@ public extension SmokeHTTP1HandlerSelector {
      */
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
-        OutputType: ValidatableOperationHTTP1OutputProtocol,
-        ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
+        ErrorType: ErrorIdentifiableByDescription,
+        OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
-        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> OutputType),
+        operation: @escaping ((InputType, ContextType, InvocationReportingType) async throws -> ()),
         allowedErrors: [(ErrorType, Int)],
         operationDelegate: OperationDelegateType)
     where DefaultOperationDelegateType.RequestHeadType == OperationDelegateType.RequestHeadType,
@@ -194,7 +163,6 @@ public extension SmokeHTTP1HandlerSelector {
             serverName: serverName, operationIdentifer: operationIdentifer, reportingConfiguration: reportingConfiguration,
             inputProvider: operationDelegate.getInputForOperation,
             operation: operation,
-            outputHandler: operationDelegate.handleResponseForOperation,
             allowedErrors: allowedErrors,
             operationDelegate: operationDelegate)
         

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import SmokeOperations
-import _SmokeOperationsConcurrency
 import NIOHTTP1
 import Logging
 import SmokeOperationsHTTP1

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
@@ -21,7 +21,6 @@ import Foundation
 import SmokeOperations
 import NIOHTTP1
 import Logging
-import SmokeOperationsHTTP1
 
 public extension SmokeHTTP1HandlerSelector {
     /**

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import SmokeOperations
-import _SmokeOperationsConcurrency
 import NIOHTTP1
 import Logging
 import SmokeOperationsHTTP1

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
@@ -21,7 +21,6 @@ import Foundation
 import SmokeOperations
 import NIOHTTP1
 import Logging
-import SmokeOperationsHTTP1
 
 public extension SmokeHTTP1HandlerSelector {
     /**

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import SmokeOperations
-import _SmokeOperationsConcurrency
 import NIOHTTP1
 import Logging
 import SmokeOperationsHTTP1

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
@@ -12,10 +12,10 @@
 // permissions and limitations under the License.
 //
 // SmokeHTTP1HandlerSelector+withInputNoOutput.swift
-// _SmokeOperationsHTTP1Concurrency
+// SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
@@ -21,7 +21,6 @@ import Foundation
 import SmokeOperations
 import NIOHTTP1
 import Logging
-import SmokeOperationsHTTP1
 
 public extension SmokeHTTP1HandlerSelector {
     /**

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import SmokeOperations
-import _SmokeOperationsConcurrency
 import NIOHTTP1
 import Logging
 import SmokeOperationsHTTP1

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
@@ -21,7 +21,6 @@ import Foundation
 import SmokeOperations
 import NIOHTTP1
 import Logging
-import SmokeOperationsHTTP1
 
 public extension SmokeHTTP1HandlerSelector {
     /**

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
@@ -12,10 +12,10 @@
 // permissions and limitations under the License.
 //
 // SmokeHTTP1HandlerSelector+withInputWithOutput.swift
-// _SmokeOperationsHTTP1Concurrency
+// SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations

--- a/Sources/_SmokeOperationsConcurrency/Export.swift
+++ b/Sources/_SmokeOperationsConcurrency/Export.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  AdditionalHeadersOperationHTTPOutput.swift
+//  Export.swift
 //  _SmokeOperationsConcurrency
 //
 

--- a/Sources/_SmokeOperationsConcurrency/Export.swift
+++ b/Sources/_SmokeOperationsConcurrency/Export.swift
@@ -1,0 +1,19 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AdditionalHeadersOperationHTTPOutput.swift
+//  _SmokeOperationsConcurrency
+//
+
+// TODO: https://github.com/amzn/smoke-framework/issues/85
+@_exported import SmokeOperations

--- a/Sources/_SmokeOperationsHTTP1Concurrency/Export.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/Export.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  AdditionalHeadersOperationHTTPOutput.swift
+//  Export.swift
 //  _SmokeOperationsHTTP1Concurrency
 //
 

--- a/Sources/_SmokeOperationsHTTP1Concurrency/Export.swift
+++ b/Sources/_SmokeOperationsHTTP1Concurrency/Export.swift
@@ -1,0 +1,19 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AdditionalHeadersOperationHTTPOutput.swift
+//  _SmokeOperationsHTTP1Concurrency
+//
+
+// TODO: https://github.com/amzn/smoke-framework/issues/85
+@_exported import SmokeOperationsHTTP1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update CI and README for Swift 5.5
2. Move async function support into non-unscored packages
3. Re-export non-unscored packages in unscored packages to avoid breaking anyone who imported the unscored package.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
