### PR TITLE
Add operation identifier to invocation context; allow known errors to be returned from Smoke operation

### DIFF
--- a/Sources/SmokeOperations/OperationHandlerExtensions.swift
+++ b/Sources/SmokeOperations/OperationHandlerExtensions.swift
@@ -66,6 +66,12 @@ public extension OperationHandler {
                 return OperationFailure(code: code,
                                         error: error)
             }
+        
+            if let knownError = error as? SmokeKnownError,
+               knownError.isErrorType(errorIdentity: .unrecognizedErrorFromExternalCall) {
+                return OperationFailure(code: 500,
+                                        error: error)
+            }
             
             return nil
     }

--- a/Sources/SmokeOperations/PerInvocationContext.swift
+++ b/Sources/SmokeOperations/PerInvocationContext.swift
@@ -17,7 +17,13 @@
 
 import Foundation
 
-public enum PerInvocationContext<ContextType, InvocationReportingType> {
+public enum PerInvocationContext<ContextType, InvocationReportingType, OperationIdentity> {
     case `static`(ContextType)
-    case provider((InvocationReportingType) -> ContextType)
+    case provider((InvocationReportingType, OperationIdentity) -> ContextType)
+}
+
+public protocol OperationAwarePerInvocationContext {
+    associatedtype OperationIdentity
+    
+    var operationIdentifier: OperationIdentity? { get }
 }

--- a/Sources/SmokeOperations/ReturnableErrorProtocols.swift
+++ b/Sources/SmokeOperations/ReturnableErrorProtocols.swift
@@ -37,3 +37,11 @@ extension Encodable where Self: SmokeReturnableError {
         return try errorEncoder.encode(self, logger: logger)
     }
 }
+
+public protocol SmokeKnownError: SmokeReturnableError {
+    func isErrorType(errorIdentity: SmokeKnownErrorIdentifiers) -> Bool
+}
+
+public enum SmokeKnownErrorIdentifiers {
+    case unrecognizedErrorFromExternalCall
+}

--- a/Sources/SmokeOperationsHTTP1/SmokePerInvocationContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokePerInvocationContextInitializer.swift
@@ -35,6 +35,8 @@ public protocol SmokePerInvocationContextInitializer {
     var reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer> { get }
         
     func getInvocationContext(invocationReporting: InvocationReportingType) -> SelectorType.ContextType
+    func getInvocationContext(invocationReporting: InvocationReportingType,
+                              operationIdentifier: SelectorType.OperationIdentifer) -> SelectorType.ContextType
     
     func onShutdown() throws
 }
@@ -54,5 +56,10 @@ public extension SmokePerInvocationContextInitializer {
     
     var reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer> {
         return SmokeReportingConfiguration()
+    }
+    
+    func getInvocationContext(invocationReporting: InvocationReportingType,
+                              operationIdentifier: SelectorType.OperationIdentifer) -> SelectorType.ContextType {
+        return getInvocationContext(invocationReporting: invocationReporting)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokePerInvocationContextInitializerV2.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokePerInvocationContextInitializerV2.swift
@@ -41,6 +41,8 @@ public protocol SmokePerInvocationContextInitializerV2 {
     var reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer> { get }
         
     func getInvocationContext(invocationReporting: InvocationReportingType) -> SelectorType.ContextType
+    func getInvocationContext(invocationReporting: InvocationReportingType,
+                              operationIdentifier: SelectorType.OperationIdentifer) -> SelectorType.ContextType
     
     func onShutdown() throws
 }
@@ -60,5 +62,10 @@ public extension SmokePerInvocationContextInitializerV2 {
     
     var reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer> {
         return SmokeReportingConfiguration()
+    }
+    
+    func getInvocationContext(invocationReporting: InvocationReportingType,
+                              operationIdentifier: SelectorType.OperationIdentifer) -> SelectorType.ContextType {
+        return getInvocationContext(invocationReporting: invocationReporting)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
@@ -42,7 +42,7 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
     public typealias InvocationReportingType = SelectorType.DefaultOperationDelegateType.InvocationReportingType
         
     let handlerSelector: SelectorType
-    let context: PerInvocationContext<SelectorType.ContextType, InvocationReportingType>
+    let context: PerInvocationContext<SelectorType.ContextType, InvocationReportingType, SelectorType.OperationIdentifer>
     let pingOperationReporting: SmokeOperationReporting
     let unknownOperationReporting: SmokeOperationReporting
     let errorDeterminingOperationReporting: SmokeOperationReporting
@@ -62,7 +62,7 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
     }
     
     public init(handlerSelector: SelectorType,
-         contextProvider: @escaping (InvocationReportingType) -> SelectorType.ContextType,
+                contextProvider: @escaping (InvocationReportingType, SelectorType.OperationIdentifer) -> SelectorType.ContextType,
          serverName: String, reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer>) {
         self.handlerSelector = handlerSelector
         self.context = .provider(contextProvider)

--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+startAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+startAsOperationServer.swift
@@ -55,7 +55,7 @@ public extension SmokeHTTP1Server {
   
     static func startAsOperationServer<SelectorType: SmokeHTTP1HandlerSelector, TraceContextType>(
         withHandlerSelector handlerSelector: SelectorType,
-        andContextProvider contextProvider: @escaping (SmokeServerInvocationReporting<TraceContextType>) -> SelectorType.ContextType,
+        andContextProvider contextProvider: @escaping (SmokeServerInvocationReporting<TraceContextType>, SelectorType.OperationIdentifer) -> SelectorType.ContextType,
         andPort port: Int = ServerDefaults.defaultPort,
         serverName: String = "Server",
         invocationStrategy: InvocationStrategy = GlobalDispatchQueueAsyncInvocationStrategy(),

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerHTTP1RequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerHTTP1RequestHandler.swift
@@ -56,7 +56,7 @@ struct OperationServerHTTP1RequestHandler<SelectorType, TraceContextType>: HTTP1
     }
     
     init(handlerSelector: SelectorType,
-         contextProvider: @escaping (InvocationReportingType) -> SelectorType.ContextType,
+         contextProvider: @escaping (InvocationReportingType, SelectorType.OperationIdentifer) -> SelectorType.ContextType,
          serverName: String, reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer>) {
         self.operationRequestHandler = StandardHTTP1OperationRequestHandler(
             handlerSelector: handlerSelector,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add operation identifier to the parameters sent for invocation context initialization.
- Allow known errors to be returned as typed errors from Smoke operations even when such error is not specified in the operation's allowed errors. Clients can opt-in error types by implementing the SmokeKnownError to specify conformance of errors to known types. For now, the only type available is `unrecognizedErrorFromExternalCall`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
