### PR TITLE
Support async APIs on older Apple OSs.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,7 +20,7 @@ jobs:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
       - name: Build
-        run: swift build
+        run: swift build -c release
       - name: Run tests
         run: swift test
   OlderVersionBuild:
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.4.3", "5.3.3", "5.2.5"]
+        swift: ["5.4.3", "5.3.3"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
@@ -36,7 +36,7 @@ jobs:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
       - name: Build
-        run: swift build
+        run: swift build -c release
       - name: Run tests
         run: swift test
   SwiftLint:

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ import PackageDescription
 let package = Package(
     name: "smoke-framework",
     platforms: [
-        .macOS(.v10_13), .iOS(.v10), .tvOS(.v10), .watchOS(.v3)
-    ],
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
+        ],
     products: [
         .library(
             name: "SmokeOperations",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-framework/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.2, 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperations
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import Logging
@@ -33,7 +33,6 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
             inputProvider: @escaping (OperationDelegateType.RequestHeadType, Data?) throws -> InputType,

--- a/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperations
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import Logging
@@ -34,7 +34,6 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer, reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,

--- a/Sources/SmokeOperations/OperationHandler+withInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withInputNoOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperations
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import Logging
@@ -36,7 +36,6 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     init<InputType: Validatable, ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer,
             reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,

--- a/Sources/SmokeOperations/OperationHandler+withInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withInputWithOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperations
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import Logging
@@ -37,7 +37,6 @@ public extension OperationHandler {
         - operationDelegate: optionally an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     init<InputType: Validatable, OutputType: Validatable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: OperationDelegate>(
             serverName: String, operationIdentifer: OperationIdentifer,

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputNoOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations
@@ -34,7 +34,6 @@ public extension SmokeHTTP1HandlerSelector {
           from the operation and their error codes.
         - inputLocation: the location in the incoming http request to decode the input from.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
             _ operationIdentifer: OperationIdentifer,
             httpMethod: HTTPMethod,
@@ -66,7 +65,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
             _ operationIdentifer: OperationIdentifer,
@@ -101,7 +99,6 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol, ErrorType: ErrorIdentifiableByDescription>(
             _ operationIdentifer: OperationIdentifer,
             httpMethod: HTTPMethod,
@@ -130,7 +127,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
             ErrorType: ErrorIdentifiableByDescription,
             OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+fromProviderWithInputWithOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations
@@ -35,7 +35,6 @@ public extension SmokeHTTP1HandlerSelector {
         - inputLocation: the location in the incoming http request to decode the input from.
         - outputLocation: the location in the outgoing http response to place the encoded output.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
             ErrorType: ErrorIdentifiableByDescription>(
             _ operationIdentifer: OperationIdentifer,
@@ -71,7 +70,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableCodable, OutputType: ValidatableCodable,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
             _ operationIdentifer: OperationIdentifer,
@@ -108,7 +106,6 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
             OutputType: ValidatableOperationHTTP1OutputProtocol,
             ErrorType: ErrorIdentifiableByDescription>(
@@ -139,7 +136,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperationProvider<InputType: ValidatableOperationHTTP1InputProtocol,
             OutputType: ValidatableOperationHTTP1OutputProtocol,
             ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputNoOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations
@@ -34,7 +34,6 @@ public extension SmokeHTTP1HandlerSelector {
           from the operation and their error codes.
         - inputLocation: the location in the incoming http request to decode the input from.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
@@ -74,7 +73,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
@@ -114,7 +112,6 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
@@ -144,7 +141,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withContextInputWithOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations
@@ -35,7 +35,6 @@ public extension SmokeHTTP1HandlerSelector {
         - inputLocation: the location in the incoming http request to decode the input from.
         - outputLocation: the location in the outgoing http response to place the encoded output.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
@@ -90,7 +89,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
@@ -143,7 +141,6 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
@@ -175,7 +172,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputNoOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations
@@ -34,7 +34,6 @@ public extension SmokeHTTP1HandlerSelector {
           from the operation and their error codes.
         - inputLocation: the location in the incoming http request to decode the input from.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
         httpMethod: HTTPMethod,
@@ -75,7 +74,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
@@ -116,7 +114,6 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
@@ -147,7 +144,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         ErrorType: ErrorIdentifiableByDescription,
         OperationDelegateType: HTTP1OperationDelegate>(

--- a/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeHTTP1HandlerSelector+withInputWithOutput.swift
@@ -15,7 +15,7 @@
 // SmokeOperationsHTTP1
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import SmokeOperations
@@ -35,7 +35,6 @@ public extension SmokeHTTP1HandlerSelector {
         - inputLocation: the location in the incoming http request to decode the input from.
         - outputLocation: the location in the outgoing http response to place the encoded output.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription>(
         _ operationIdentifer: OperationIdentifer,
@@ -91,7 +90,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableCodable, OutputType: ValidatableCodable,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(
         _ operationIdentifer: OperationIdentifer,
@@ -145,7 +143,6 @@ public extension SmokeHTTP1HandlerSelector {
         - allowedErrors: the errors that can be serialized as responses
           from the operation and their error codes.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription>(
@@ -178,7 +175,6 @@ public extension SmokeHTTP1HandlerSelector {
         - operationDelegate: an operation-specific delegate to use when
           handling the operation.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     mutating func addHandlerForOperation<InputType: ValidatableOperationHTTP1InputProtocol,
         OutputType: ValidatableOperationHTTP1OutputProtocol,
         ErrorType: ErrorIdentifiableByDescription, OperationDelegateType: HTTP1OperationDelegate>(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Remove `@available` annotation from async APIs, increase the requirement for non Linux platforms to the upcoming 5.5.2 (which will backport async support to the earlier Apple OSs).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
