### PR TITLE
Update CI for Swift 5.6, remove 5.3.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04]
-        swift: ["5.5"]
+        swift: ["5.6"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
+      - uses: fwal/setup-swift@v1.14.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -28,10 +28,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.4.3", "5.3.3"]
+        swift: ["5.5.3", "5.4.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
+      - uses: fwal/setup-swift@v1.14.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 //
 // Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-framework/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.4|5.5|5.6-orange.svg?style=flat" alt="Swift 5.4, 5.5 and 5.6 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeOperationsHTTP1Server/StandardJSONSmokeAsyncServerPerInvocationContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/StandardJSONSmokeAsyncServerPerInvocationContextInitializer.swift
@@ -33,7 +33,7 @@ public protocol StandardJSONSmokeAsyncServerPerInvocationContextInitializer: Smo
                 StandardSmokeHTTP1HandlerSelector<ContextType, JSONPayloadHTTP1OperationDelegate<SmokeInvocationTraceContext>,
                                                   OperationIdentifer> {
     associatedtype ContextType
-    associatedtype OperationIdentifer: OperationIdentity
+    associatedtype OperationIdentifer
     
     typealias OperationsInitializerType = ((inout StandardSmokeHTTP1HandlerSelector<ContextType, JSONPayloadHTTP1OperationDelegate<SmokeInvocationTraceContext>, OperationIdentifer>) -> Void)
 }

--- a/Sources/SmokeOperationsHTTP1Server/StandardJSONSmokeAsyncServerStaticContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/StandardJSONSmokeAsyncServerStaticContextInitializer.swift
@@ -33,7 +33,7 @@ public protocol StandardJSONSmokeAsyncServerStaticContextInitializer: SmokeAsync
                 StandardSmokeHTTP1HandlerSelector<ContextType, JSONPayloadHTTP1OperationDelegate<SmokeInvocationTraceContext>,
                                                   OperationIdentifer> {
     associatedtype ContextType
-    associatedtype OperationIdentifer: OperationIdentity
+    associatedtype OperationIdentifer
     
     typealias OperationsInitializerType = ((inout StandardSmokeHTTP1HandlerSelector<ContextType, JSONPayloadHTTP1OperationDelegate<SmokeInvocationTraceContext>, OperationIdentifer>) -> Void)
 }

--- a/Sources/SmokeOperationsHTTP1Server/StandardJSONSmokeServerPerInvocationContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/StandardJSONSmokeServerPerInvocationContextInitializer.swift
@@ -31,7 +31,7 @@ public protocol StandardJSONSmokeServerPerInvocationContextInitializer: SmokeSer
                 StandardSmokeHTTP1HandlerSelector<ContextType, JSONPayloadHTTP1OperationDelegate<SmokeInvocationTraceContext>,
                                                   OperationIdentifer> {
     associatedtype ContextType
-    associatedtype OperationIdentifer: OperationIdentity
+    associatedtype OperationIdentifer
     
     typealias OperationsInitializerType = ((inout StandardSmokeHTTP1HandlerSelector<ContextType, JSONPayloadHTTP1OperationDelegate<SmokeInvocationTraceContext>, OperationIdentifer>) -> Void)
 }

--- a/Sources/SmokeOperationsHTTP1Server/StandardJSONSmokeServerStaticContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/StandardJSONSmokeServerStaticContextInitializer.swift
@@ -31,7 +31,7 @@ public protocol StandardJSONSmokeServerStaticContextInitializer: SmokeServerStat
                 StandardSmokeHTTP1HandlerSelector<ContextType, JSONPayloadHTTP1OperationDelegate<SmokeInvocationTraceContext>,
                                                   OperationIdentifer> {
     associatedtype ContextType
-    associatedtype OperationIdentifer: OperationIdentity
+    associatedtype OperationIdentifer
     
     typealias OperationsInitializerType = ((inout StandardSmokeHTTP1HandlerSelector<ContextType, JSONPayloadHTTP1OperationDelegate<SmokeInvocationTraceContext>, OperationIdentifer>) -> Void)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update CI for Swift 5.6, remove 5.3.
2. Remove redundant conformance warnings in Swift 5.6


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
