### PR TITLE
Avoid logging pings and move some logging to trace.

### DIFF
--- a/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
+++ b/Sources/SmokeHTTP1/HTTP1ChannelInboundHandler.swift
@@ -239,19 +239,19 @@ class HTTP1ChannelInboundHandler<HTTP1RequestHandlerType: HTTP1RequestHandler>: 
         case .head(let requestHead):
             let logger = self.state.requestReceived(requestHead: requestHead)
 
-            logger.debug("Request head received.")
+            logger.trace("Request head received.")
         case .body(var byteBuffer):
             let byteBufferSize = byteBuffer.readableBytes
             let newData = byteBuffer.readData(length: byteBufferSize)
             
             let logger = self.state.partialBodyReceived(bodyPart: newData)
 
-            logger.debug("Request body part of \(byteBufferSize) bytes received.")
+            logger.trace("Request body part of \(byteBufferSize) bytes received.")
         case .end:
             // this signals that the head and all possible body parts have been received
             let pendingResponse = self.state.requestFullyReceived()
             
-            pendingResponse.logger.debug("Request end received.")
+            pendingResponse.logger.trace("Request end received.")
 
             handleCompleteRequest(context: context, pendingResponse: pendingResponse)
         }
@@ -266,7 +266,7 @@ class HTTP1ChannelInboundHandler<HTTP1RequestHandlerType: HTTP1RequestHandler>: 
         let bodyData = pendingResponse.bodyData
         let requestHead = pendingResponse.requestHead
         
-        logger.debug("Handling request body with \(bodyData?.count ?? 0) size.")
+        logger.trace("Handling request body with \(bodyData?.count ?? 0) size.")
         
         func onComplete() {
             self.state.responseFullSent()

--- a/Sources/SmokeOperations/OperationHandler.swift
+++ b/Sources/SmokeOperations/OperationHandler.swift
@@ -34,6 +34,7 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
         _ requestLogger: Logger, _ internalRequestId: String, _ invocationReportingProvider: (Logger) -> InvocationReportingType) -> ()
     
     private let operationFunction: OperationResultDataInputFunction
+    public let operationIdentifer: OperationIdentifer
     
     /**
      * Handle for an operation handler delegates the input to the wrapped handling function
@@ -124,6 +125,7 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
                 reportingConfiguration: SmokeReportingConfiguration<OperationIdentifer>,
                 operationFunction: @escaping OperationResultDataInputFunction) {
         self.operationFunction = operationFunction
+        self.operationIdentifer = operationIdentifer
     }
     
     /**
@@ -225,5 +227,6 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
         }
         
         self.operationFunction = newFunction
+        self.operationIdentifer = operationIdentifer
     }
 }

--- a/Sources/SmokeOperationsHTTP1/HTTP1OperationRequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/HTTP1OperationRequestHandler.swift
@@ -40,5 +40,6 @@ public protocol HTTP1OperationRequestHandler {
      */
     func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                 invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String,
-                invocationReportingProvider: @escaping (Logger) -> InvocationReportingType)
+                invocationReportingProvider: @escaping (Logger) -> InvocationReportingType,
+                reportRequest: () -> ())
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -79,7 +79,7 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
     
     public func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?, logger: inout Logger, internalRequestId: String) {
         var logElements: [String] = []
-        logElements.append("Incoming \(requestHead.method) request received.")
+        logElements.append("Incoming \(requestHead.method) request received for uri \(requestHead.uri).")
         
         if let externalRequestId = self.externalRequestId {
             logElements.append("Received \(requestIdHeader) header '\(externalRequestId)'")

--- a/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
@@ -78,7 +78,8 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
 
     public func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                        invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String,
-                       invocationReportingProvider: @escaping (Logger) -> InvocationReportingType) {
+                       invocationReportingProvider: @escaping (Logger) -> InvocationReportingType,
+                       reportRequest: () -> ()) {
         func getInvocationContextForAnonymousRequest(requestReporting: SmokeOperationReporting)
                 -> SmokeInvocationContext<InvocationReportingType> {
             var decoratedRequestLogger: Logger = requestLogger
@@ -99,6 +100,8 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
             
             return
         }
+        
+        reportRequest()
         
         let uriComponents = requestHead.uri.split(separator: "?", maxSplits: 1)
         let path = String(uriComponents[0])

--- a/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
@@ -68,13 +68,13 @@ public struct StandardSmokeHTTP1HandlerSelector<ContextType, DefaultOperationDel
             guard let tokenizedHandler = getTokenizedHandler(uri: uri,
                                                              httpMethod: httpMethod, requestLogger: requestLogger) else {
                 throw SmokeOperationsError.invalidOperation(reason:
-                    "Invalid operation with uri '\(lowerCasedUri)', method '\(httpMethod)'")
+                    "Invalid operation with uri '\(uri)', method '\(httpMethod)'")
                 }
             
                 return tokenizedHandler
         }
         
-        requestLogger.trace("Operation handler selected with uri '\(lowerCasedUri)', method '\(httpMethod)'")
+        requestLogger.info("Operation handler '\(handler.operationIdentifer)' selected for uri '\(uri)', method '\(httpMethod)'")
         
         return (handler, .null)
     }

--- a/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardSmokeHTTP1HandlerSelector.swift
@@ -74,7 +74,7 @@ public struct StandardSmokeHTTP1HandlerSelector<ContextType, DefaultOperationDel
                 return tokenizedHandler
         }
         
-        requestLogger.info("Operation handler selected with uri '\(lowerCasedUri)', method '\(httpMethod)'")
+        requestLogger.trace("Operation handler selected with uri '\(lowerCasedUri)', method '\(httpMethod)'")
         
         return (handler, .null)
     }

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerHTTP1RequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerHTTP1RequestHandler.swift
@@ -79,14 +79,17 @@ struct OperationServerHTTP1RequestHandler<SelectorType, TraceContextType>: HTTP1
         
         let traceContext = TraceContextType(requestHead: requestHead, bodyData: body)
         var decoratedRequestLogger: Logger = requestLogger
-        traceContext.handleInwardsRequestStart(requestHead: requestHead, bodyData: body,
-                                               logger: &decoratedRequestLogger, internalRequestId: internalRequestId)
         
         func invocationReportingProvider(logger: Logger) -> SmokeServerInvocationReporting<TraceContextType> {
             return SmokeServerInvocationReporting(logger: logger,
                                                   internalRequestId: internalRequestId, traceContext: traceContext,
                                                   eventLoop: eventLoop,
                                                   outwardsRequestAggregator: outwardsRequestAggregator)
+        }
+        
+        func reportRequest() {
+            traceContext.handleInwardsRequestStart(requestHead: requestHead, bodyData: body,
+                                                   logger: &decoratedRequestLogger, internalRequestId: internalRequestId)
         }
         
         // let it be handled
@@ -96,6 +99,7 @@ struct OperationServerHTTP1RequestHandler<SelectorType, TraceContextType>: HTTP1
                                             invocationStrategy: invocationStrategy,
                                             requestLogger: requestLogger,
                                             internalRequestId: internalRequestId,
-                                            invocationReportingProvider: invocationReportingProvider)
+                                            invocationReportingProvider: invocationReportingProvider,
+                                            reportRequest: reportRequest)
     }
 }

--- a/Sources/SmokeOperationsHTTP1Server/StandardHTTP1ResponseHandler.swift
+++ b/Sources/SmokeOperationsHTTP1Server/StandardHTTP1ResponseHandler.swift
@@ -78,7 +78,7 @@ public struct StandardHTTP1ResponseHandler<
     public func complete(invocationContext: InvocationContext, status: HTTPResponseStatus,
                          responseComponents: HTTP1ServerResponseComponents) {
         let bodySize = handleComplete(invocationContext: invocationContext, status: status,
-                                      responseComponents: responseComponents, completeSilently: false)
+                                      responseComponents: responseComponents, reportCompletion: true)
         
         invocationContext.logger.trace("Http response send: status '\(status.code)', body size '\(bodySize)'")
     }
@@ -93,7 +93,7 @@ public struct StandardHTTP1ResponseHandler<
     public func completeSilently(invocationContext: InvocationContext, status: HTTPResponseStatus,
                                  responseComponents: HTTP1ServerResponseComponents) {
         let bodySize = handleComplete(invocationContext: invocationContext, status: status,
-                                      responseComponents: responseComponents, completeSilently: true)
+                                      responseComponents: responseComponents, reportCompletion: false)
         
         invocationContext.logger.trace("Http response send: status '\(status.code)', body size '\(bodySize)'")
     }
@@ -107,7 +107,7 @@ public struct StandardHTTP1ResponseHandler<
     
     private func handleComplete(invocationContext: InvocationContext, status: HTTPResponseStatus,
                                 responseComponents: HTTP1ServerResponseComponents,
-                                completeSilently: Bool) -> Int {
+                                reportCompletion: Bool) -> Int {
         var headers = HTTPHeaders()
         
         let buffer: ByteBuffer?
@@ -138,7 +138,7 @@ public struct StandardHTTP1ResponseHandler<
             headers.add(name: header.0, value: header.1)
         }
         
-        if !completeSilently {
+        if reportCompletion {
             invocationContext.handleInwardsRequestComplete(httpHeaders: &headers, status: status, body: responseComponents.body)
         }
         

--- a/Sources/SmokeOperationsHTTP1Server/StandardHTTP1ResponseHandler.swift
+++ b/Sources/SmokeOperationsHTTP1Server/StandardHTTP1ResponseHandler.swift
@@ -140,59 +140,59 @@ public struct StandardHTTP1ResponseHandler<
         
         if reportCompletion {
             invocationContext.handleInwardsRequestComplete(httpHeaders: &headers, status: status, body: responseComponents.body)
-        }
         
-        if let smokeInwardsRequestContext = self.smokeInwardsRequestContext {
-            let requestLatency = Date().timeIntervalSince(smokeInwardsRequestContext.requestStart).milliseconds
-            let serviceCallCount = smokeInwardsRequestContext.retriableOutputRequestRecords.count
-            let serviceCallLatency = smokeInwardsRequestContext.retriableOutputRequestRecords.reduce(0) { (retriableRequestSum, retriableRequestRecord) in
-                return retriableRequestSum + retriableRequestRecord.outputRequests.reduce(0) { (requestSum, requestRecord) in
-                    return requestSum + requestRecord.requestLatency.milliseconds
+            if let smokeInwardsRequestContext = self.smokeInwardsRequestContext {
+                let requestLatency = Date().timeIntervalSince(smokeInwardsRequestContext.requestStart).milliseconds
+                let serviceCallCount = smokeInwardsRequestContext.retriableOutputRequestRecords.count
+                let serviceCallLatency = smokeInwardsRequestContext.retriableOutputRequestRecords.reduce(0) { (retriableRequestSum, retriableRequestRecord) in
+                    return retriableRequestSum + retriableRequestRecord.outputRequests.reduce(0) { (requestSum, requestRecord) in
+                        return requestSum + requestRecord.requestLatency.milliseconds
+                    }
                 }
-            }
-            let retryWaitLatency = smokeInwardsRequestContext.retryAttemptRecords.reduce(0) { (retryWaitSum, retryAttemptRecord) in
-                return retryWaitSum + retryAttemptRecord.retryWait.milliseconds
-            }
-            let retriedServiceCalls = smokeInwardsRequestContext.retriableOutputRequestRecords.filter { requestRecord in
-                return requestRecord.outputRequests.count > 1
-            }
-            let serviceOnlyLatency = requestLatency - serviceCallLatency - retryWaitLatency
-            
-            var logComponents: [String] = []
-            
-            if serviceCallCount == 0 {
-                let logMessage = "Request completed in \(requestLatency) ms; (no service calls)."
-                logComponents.append("\(logMessage)")
-            } else {
-                let logMessage = "Request completed in \(requestLatency) ms; "
-                    + "\(serviceOnlyLatency) ms excluding service calls (there was \(serviceCallCount); "
-                    + "\(serviceCallLatency) ms service call latency, \(retryWaitLatency) ms retry backoff)."
-                logComponents.append("\(logMessage)")
-            }
-            
-            if retriedServiceCalls.count == 1 {
-                logComponents.append("1 outward service call was retried.")
-            } else {
-                logComponents.append("\(retriedServiceCalls.count) outward service calls were retried.")
-            }
-            
-            invocationContext.logger.trace("\(logComponents.joined(separator: " "))")
-            
-            invocationContext.latencyTimer?.recordMilliseconds(requestLatency)
-            invocationContext.serviceLatencyTimer?.recordMilliseconds(serviceOnlyLatency)
-            invocationContext.outwardsServiceCallLatencySumTimer?.recordMilliseconds(serviceCallLatency)
-            invocationContext.outwardsServiceCallRetryWaitSumTimer?.recordMilliseconds(retryWaitLatency)
-            
-            if status.code >= 200 && status.code < 300 {
-                invocationContext.successCounter?.increment()
-            } else if status.code >= 400 {
-                if status.code < 500 {
-                    invocationContext.failure4XXCounter?.increment()
+                let retryWaitLatency = smokeInwardsRequestContext.retryAttemptRecords.reduce(0) { (retryWaitSum, retryAttemptRecord) in
+                    return retryWaitSum + retryAttemptRecord.retryWait.milliseconds
+                }
+                let retriedServiceCalls = smokeInwardsRequestContext.retriableOutputRequestRecords.filter { requestRecord in
+                    return requestRecord.outputRequests.count > 1
+                }
+                let serviceOnlyLatency = requestLatency - serviceCallLatency - retryWaitLatency
+                
+                var logComponents: [String] = []
+                
+                if serviceCallCount == 0 {
+                    let logMessage = "Request completed in \(requestLatency) ms; (no service calls)."
+                    logComponents.append("\(logMessage)")
                 } else {
-                    invocationContext.failure5XXCounter?.increment()
+                    let logMessage = "Request completed in \(requestLatency) ms; "
+                        + "\(serviceOnlyLatency) ms excluding service calls (there was \(serviceCallCount); "
+                        + "\(serviceCallLatency) ms service call latency, \(retryWaitLatency) ms retry backoff)."
+                    logComponents.append("\(logMessage)")
                 }
                 
-                invocationContext.specificFailureStatusCounters?[status.code]?.increment()
+                if retriedServiceCalls.count == 1 {
+                    logComponents.append("1 outward service call was retried.")
+                } else {
+                    logComponents.append("\(retriedServiceCalls.count) outward service calls were retried.")
+                }
+                
+                invocationContext.logger.info("\(logComponents.joined(separator: " "))")
+                
+                invocationContext.latencyTimer?.recordMilliseconds(requestLatency)
+                invocationContext.serviceLatencyTimer?.recordMilliseconds(serviceOnlyLatency)
+                invocationContext.outwardsServiceCallLatencySumTimer?.recordMilliseconds(serviceCallLatency)
+                invocationContext.outwardsServiceCallRetryWaitSumTimer?.recordMilliseconds(retryWaitLatency)
+                
+                if status.code >= 200 && status.code < 300 {
+                    invocationContext.successCounter?.increment()
+                } else if status.code >= 400 {
+                    if status.code < 500 {
+                        invocationContext.failure4XXCounter?.increment()
+                    } else {
+                        invocationContext.failure5XXCounter?.increment()
+                    }
+                    
+                    invocationContext.specificFailureStatusCounters?[status.code]?.increment()
+                }
             }
         }
         

--- a/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
+++ b/Tests/SmokeOperationsHTTP1Tests/TestConfiguration.swift
@@ -266,7 +266,7 @@ where SelectorType: SmokeHTTP1HandlerSelector, SelectorType.ContextType == Examp
                    responseHandler: responseHandler,
                    invocationStrategy: TestInvocationStrategy(), requestLogger: Logger(label: "Test"),
                    internalRequestId: "internalRequestId",
-                   invocationReportingProvider: invocationReportingProvider)
+                   invocationReportingProvider: invocationReportingProvider, reportRequest: { })
     
     return responseHandler.response!
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Avoid logging pings. A `reportRequest` function is passed into `HTTP1OperationRequestHandler.handle` allowing the conforming type to choose when to report the request start to the `OperationTraceContext`. By default (in `StandardHTTP1OperationRequestHandler`) this function will only be called if the request is not a ping. 
2. `StandardHTTP1ResponseHandler. handleComplete` takes an additional `reportCompletion` parameter, which if false will not report request completion to the `OperationTraceContext`.
3. Reduce a number of logging statements from `debug` to 'trace`
4. Reduce the log statement in `StandardHTTP1ResponseHandler.complete` from `info` to `trace` as it is duplicated by any logging in the `OperationTraceContext`

This is a breaking change and will be part of the next major version, 3.X.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
