### PR TITLE
Use checked rather than unsafe continuations (2.x branch).

### DIFF
--- a/Sources/SmokeHTTP1/StandardSmokeHTTP1Server.swift
+++ b/Sources/SmokeHTTP1/StandardSmokeHTTP1Server.swift
@@ -25,7 +25,7 @@ import SmokeInvocation
 private struct ServerShutdownDetails {
     let completionHandlers: [() -> Void]
 #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
-    let awaitingContinuations: [UnsafeContinuation<Void, Error>]
+    let awaitingContinuations: [CheckedContinuation<Void, Error>]
 #endif
 }
 
@@ -54,7 +54,7 @@ public class StandardSmokeHTTP1Server<HTTP1RequestHandlerType: HTTP1RequestHandl
     }
     private var shutdownCompletionHandlers: [() -> Void] = []
 #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
-    private var shutdownWaitingContinuations: [UnsafeContinuation<Void, Error>] = []
+    private var shutdownWaitingContinuations: [CheckedContinuation<Void, Error>] = []
 #endif
     private var serverState: State = .initialized
     private var stateLock: NSLock = NSLock()
@@ -270,7 +270,7 @@ public class StandardSmokeHTTP1Server<HTTP1RequestHandlerType: HTTP1RequestHandl
     
 #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     public func untilShutdown() async throws {
-        return try await withUnsafeThrowingContinuation { cont in
+        return try await withCheckedThrowingContinuation { cont in
             if !addContinuationIfShutdown(newContinuation: cont) {
                 // continuation will be resumed when the server shuts down
             } else {
@@ -443,7 +443,7 @@ public class StandardSmokeHTTP1Server<HTTP1RequestHandlerType: HTTP1RequestHandl
     }
     
 #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
-    public func addContinuationIfShutdown(newContinuation: UnsafeContinuation<Void, Error>) -> Bool {
+    public func addContinuationIfShutdown(newContinuation: CheckedContinuation<Void, Error>) -> Bool {
         stateLock.lock()
         defer {
             stateLock.unlock()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use checked rather than unsafe continuations as they guard against misuse of the continuation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
