### PR TITLE
Make SmokeInwardsRequestContext thread safe.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "70826d038d5bdc3142a386b735792d87ef7a5dfc",
-          "version": "1.8.1"
+          "revision": "794dc9d42720af97cedd395e8cd2add9173ffd9a",
+          "version": "1.11.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "f4c56e39894e50de9cbb82bbc38e3cdd41812b3e",
-          "version": "2.11.0"
+          "revision": "6e423be68a8415dc387ba9230ad2442c4fd3e5c1",
+          "version": "2.13.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
-          "version": "2.2.0"
+          "revision": "1c1408bf8fc21be93713e897d2badf500ea38419",
+          "version": "2.3.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "213eb6887e526e0dfac526a2eae559a1893ebbac",
-          "version": "2.36.0"
+          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
+          "version": "2.40.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-          "version": "1.10.2"
+          "revision": "a75e92bde3683241c15df3dd905b7a6dcac4d551",
+          "version": "1.12.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
-          "version": "1.19.1"
+          "revision": "108ac15087ea9b79abb6f6742699cf31de0e8772",
+          "version": "1.22.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "2b329e37e9dd34fb382655181a680261d58cbbf1",
-          "version": "2.17.1"
+          "revision": "c30c680c78c99afdabf84805a83c8745387c4ac7",
+          "version": "2.20.2"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
-          "version": "1.11.3"
+          "revision": "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
+          "version": "1.13.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.7.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.13.2"),
     ],
     targets: [
         .target(

--- a/Sources/SmokeHTTP1/SmokeInwardsRequestContext.swift
+++ b/Sources/SmokeHTTP1/SmokeInwardsRequestContext.swift
@@ -31,22 +31,55 @@ internal class StandardSmokeInwardsRequestContext: SmokeInwardsRequestContext, O
     private(set) var retriableOutputRequestRecords: [RetriableOutputRequestRecord]
     private(set) var retryAttemptRecords: [RetryAttemptRecord]
     
+    internal let accessQueue = DispatchQueue(
+                label: "com.amazon.SmokeFramework.StandardSmokeInwardsRequestContext.accessQueue",
+                target: DispatchQueue.global())
+    
     init(requestStart: Date) {
         self.requestStart = requestStart
         self.retriableOutputRequestRecords = []
         self.retryAttemptRecords = []
     }
     
+    func recordOutwardsRequest(outputRequestRecord: OutputRequestRecord, onCompletion: @escaping () -> ()) {
+        self.accessQueue.async {
+            let retriableOutwardsRequest = SmokeRetriableOutputRequestRecord(outputRequests: [outputRequestRecord])
+            
+            self.retriableOutputRequestRecords.append(retriableOutwardsRequest)
+            
+            onCompletion()
+        }
+    }
+    
+    func recordRetryAttempt(retryAttemptRecord: RetryAttemptRecord, onCompletion: @escaping () -> ()) {
+        self.accessQueue.async {
+            self.retryAttemptRecords.append(retryAttemptRecord)
+            
+            onCompletion()
+        }
+    }
+    
+    func recordRetriableOutwardsRequest(retriableOutwardsRequest: RetriableOutputRequestRecord, onCompletion: @escaping () -> ()) {
+        self.accessQueue.async {
+            self.retriableOutputRequestRecords.append(retriableOutwardsRequest)
+            
+            onCompletion()
+        }
+    }
+    
+    @available(swift, deprecated: 2.0, message: "Not thread-safe")
     func recordOutwardsRequest(outputRequestRecord: OutputRequestRecord) {
         let retriableOutwardsRequest = SmokeRetriableOutputRequestRecord(outputRequests: [outputRequestRecord])
         
         self.retriableOutputRequestRecords.append(retriableOutwardsRequest)
     }
     
+    @available(swift, deprecated: 2.0, message: "Not thread-safe")
     func recordRetryAttempt(retryAttemptRecord: RetryAttemptRecord) {
         self.retryAttemptRecords.append(retryAttemptRecord)
     }
     
+    @available(swift, deprecated: 2.0, message: "Not thread-safe")
     func recordRetriableOutwardsRequest(retriableOutwardsRequest: RetriableOutputRequestRecord) {
         self.retriableOutputRequestRecords.append(retriableOutwardsRequest)
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Address an issue where parallel service calls within the same server request could cause the application to crash due to mutation of `SmokeInwardsRequestContext`'s internal mutable state from multiple threads. The new implementations in `SmokeInwardsRequestContext` use a dispatch queue to serialise access to the class' mutable state. The existing methods have been marked as deprecated due to the likelihood that they will not be thread safe.

This is a follow up to https://github.com/amzn/smoke-http/pull/107.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
