### PR TITLE
Log body data at info level for input to and output from incoming req…

### DIFF
--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -90,10 +90,7 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
         
         if let bodyData = bodyData {
             logMetadata["bodyBytesCount"] = "\(bodyData.count)"
-            
-            if logger.logLevel <= .debug {
-                logMetadata["bodyData"] = "\(bodyData.debugString)"
-            }
+            logMetadata["bodyData"] = "\(bodyData.debugString)"
         }
         
         // log details about the incoming request
@@ -115,10 +112,7 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
         if let body = body {
             logMetadata["contentType"] = "\(body.contentType)"
             logMetadata["bodyBytesCount"] = "\(body.data.count)"
-            
-            if logger.logLevel <= .debug {
-                logMetadata["bodyData"] = "\(body.data.debugString)"
-            }
+            logMetadata["bodyData"] = "\(body.data.debugString)"
         }
         
         let level: Logger.Level


### PR DESCRIPTION
…uests

*Issue #, if available:*

*Description of changes:* This change moves the logging level of body data to INFO for incoming requests. The data logged is the request data incoming to the server and the response data sent from the server back to the client.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
