### PR TITLE
Split out status.reasonPhrase and status.code when logging responses.

### DIFF
--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -107,7 +107,8 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             httpHeaders.add(name: traceIdHeader, value: traceId)
         }
         
-        var logMetadata: Logger.Metadata = ["status": "\(status)"]
+        var logMetadata: Logger.Metadata = ["status": "\(status.reasonPhrase)",
+                                            "statusCode": "\(status.code)"]
         
         if let body = body {
             logMetadata["contentType"] = "\(body.contentType)"
@@ -186,8 +187,9 @@ extension SmokeInvocationTraceContext: InvocationTraceContext {
             logMetadata["result"] = "failure"
         }
         
-        if let code = response?.status.code {
-            logMetadata["status"] = "\(code)"
+        if let status = response?.status {
+            logMetadata["statusCode"] = "\(status.code)"
+            logMetadata["status"] = "\(status.reasonPhrase)"
         }
         
         if let requestIds = response?.headers[requestIdHeader], !requestIds.isEmpty {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Split out status.reasonPhrase and status.code when logging responses. This avoids logging the Swift object for custom response codes and makes searching logs for specific error codes easier.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
