### PR TITLE
Add option to process requests on the cooperative or custom thread pool

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,11 +11,11 @@ jobs:
     name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
-        swift: ["5.7"]
+        os: [ubuntu-22.04, ubuntu-20.04]
+        swift: ["5.7.2"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.18.0
+      - uses: swift-actions/setup-swift@v1.21.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
         swift: ["5.6.3", "5.5.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.18.0
+      - uses: swift-actions/setup-swift@v1.21.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Sources/SmokeOperations/OperationHandler.swift
+++ b/Sources/SmokeOperations/OperationHandler.swift
@@ -221,18 +221,12 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
             // To avoid retaining the original body `Data` object, `body` should not be referenced in this
             // invocation.
             if ignoreInvocationStrategy {
-                inputDecodeResult.handle(
-                    requestHead: requestHead,
-                    context: context,
-                    responseHandler: responseHandler,
-                    operationDelegate: operationDelegate)
+                inputDecodeResult.handle(requestHead: requestHead, context: context,
+                    responseHandler: responseHandler, operationDelegate: operationDelegate)
             } else {
                 invocationStrategy.invoke {
-                    inputDecodeResult.handle(
-                        requestHead: requestHead,
-                        context: context,
-                        responseHandler: responseHandler,
-                        operationDelegate: operationDelegate)
+                    inputDecodeResult.handle(requestHead: requestHead, context: context,
+                        responseHandler: responseHandler, operationDelegate: operationDelegate)
                 }
             }
         }

--- a/Sources/SmokeOperations/SmokeOperationReporting.swift
+++ b/Sources/SmokeOperations/SmokeOperationReporting.swift
@@ -48,32 +48,36 @@ public struct SmokeOperationReporting {
                                                        configuration: SmokeReportingConfiguration<OperationIdentifer>) {
         let operationName = request.description
         
+        func getCounter(metricName: String) -> Counter {
+            let counterDimensions = [(namespaceDimension, serverName),
+                                     (operationNameDimension, operationName),
+                                     (metricNameDimension, metricName)]
+            return Counter(label: "\(serverName).\(operationName).\(metricName)",
+                           dimensions: counterDimensions)
+        }
+        
+        func getTimer(metricName: String) -> Timer {
+            let timerDimensions = [(namespaceDimension, serverName),
+                                   (operationNameDimension, operationName),
+                                   (metricNameDimension, metricName)]
+            return Timer(label: "\(serverName).\(operationName).\(metricName)",
+                         dimensions: timerDimensions)
+        }
+        
         if configuration.reportSuccessForRequest(request) {
-            let successCounterDimensions = [(namespaceDimension, serverName),
-                                            (operationNameDimension, operationName),
-                                            (metricNameDimension, successCountMetric)]
-            successCounter = Counter(label: "\(serverName).\(operationName).\(successCountMetric)",
-                                     dimensions: successCounterDimensions)
+            successCounter = getCounter(metricName: successCountMetric)
         } else {
             successCounter = nil
         }
         
         if configuration.reportFailure5XXForRequest(request) {
-            let failure5XXCounterDimensions = [(namespaceDimension, serverName),
-                                               (operationNameDimension, operationName),
-                                               (metricNameDimension, failure5XXCountMetric)]
-            failure5XXCounter = Counter(label: "\(serverName).\(operationName).\(failure5XXCountMetric)",
-                                        dimensions: failure5XXCounterDimensions)
+            failure5XXCounter = getCounter(metricName: failure5XXCountMetric)
         } else {
             failure5XXCounter = nil
         }
         
         if configuration.reportFailure4XXForRequest(request) {
-            let failure4XXCounterDimensions = [(namespaceDimension, serverName),
-                                               (operationNameDimension, operationName),
-                                               (metricNameDimension, failure4XXCountMetric)]
-            failure4XXCounter = Counter(label: "\(serverName).\(operationName).\(failure4XXCountMetric)",
-                                        dimensions: failure4XXCounterDimensions)
+            failure4XXCounter = getCounter(metricName: failure4XXCountMetric)
         } else {
             failure4XXCounter = nil
         }
@@ -82,11 +86,7 @@ public struct SmokeOperationReporting {
            let specificFailureStatusesToReport = configuration.specificFailureStatusesToReport {
             let countersWithStatusCodes: [(UInt, Counter)] = specificFailureStatusesToReport.map { statusCode in
                 let metricName = String(format: specificFailureStatusCountMetricFormat, statusCode)
-                let specificFailureStatusDimensions = [(namespaceDimension, serverName),
-                                                       (operationNameDimension, operationName),
-                                                       (metricNameDimension, metricName)]
-                let specificFailureStatusCounter = Counter(label: "\(serverName).\(operationName).\(metricName)",
-                                                           dimensions: specificFailureStatusDimensions)
+                let specificFailureStatusCounter = getCounter(metricName: metricName)
                 return (statusCode, specificFailureStatusCounter)
             }
             specificFailureStatusCounters = Dictionary(uniqueKeysWithValues: countersWithStatusCodes)
@@ -95,41 +95,25 @@ public struct SmokeOperationReporting {
         }
         
         if configuration.reportLatencyForRequest(request) {
-            let latencyTimeDimensions = [(namespaceDimension, serverName),
-                                         (operationNameDimension, operationName),
-                                         (metricNameDimension, latencyTimeMetric)]
-            latencyTimer = Metrics.Timer(label: "\(serverName).\(operationName).\(latencyTimeMetric)",
-                                         dimensions: latencyTimeDimensions)
+            latencyTimer = getTimer(metricName: latencyTimeMetric)
         } else {
             latencyTimer = nil
         }
         
         if configuration.reportServiceLatencyForRequest(request) {
-            let serviceLatencyTimeDimensions = [(namespaceDimension, serverName),
-                                                (operationNameDimension, operationName),
-                                                (metricNameDimension, serviceLatencyTimeMetric)]
-            serviceLatencyTimer = Metrics.Timer(label: "\(serverName).\(operationName).\(serviceLatencyTimeMetric)",
-                                                dimensions: serviceLatencyTimeDimensions)
+            serviceLatencyTimer = getTimer(metricName: serviceLatencyTimeMetric)
         } else {
             serviceLatencyTimer = nil
         }
         
         if configuration.reportOutwardsServiceCallLatencySumForRequest(request) {
-            let serviceLatencyTimeDimensions = [(namespaceDimension, serverName),
-                                                (operationNameDimension, operationName),
-                                                (metricNameDimension, outwardsServiceCallLatencySumMetric)]
-            outwardsServiceCallLatencySumTimer = Metrics.Timer(label: "\(serverName).\(operationName).\(outwardsServiceCallLatencySumMetric)",
-                                                               dimensions: serviceLatencyTimeDimensions)
+            outwardsServiceCallLatencySumTimer = getTimer(metricName: outwardsServiceCallLatencySumMetric)
         } else {
             outwardsServiceCallLatencySumTimer = nil
         }
         
         if configuration.reportOutwardsServiceCallRetryWaitLatencySumForRequest(request) {
-            let serviceLatencyTimeDimensions = [(namespaceDimension, serverName),
-                                                (operationNameDimension, operationName),
-                                                (metricNameDimension, outwardsServiceCallRetryWaitSumMetric)]
-            outwardsServiceCallRetryWaitSumTimer = Metrics.Timer(label: "\(serverName).\(operationName).\(outwardsServiceCallRetryWaitSumMetric)",
-                                                                 dimensions: serviceLatencyTimeDimensions)
+            outwardsServiceCallRetryWaitSumTimer = getTimer(metricName: outwardsServiceCallRetryWaitSumMetric)
         } else {
             outwardsServiceCallRetryWaitSumTimer = nil
         }

--- a/Sources/SmokeOperationsHTTP1/SmokeAsyncPerInvocationContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeAsyncPerInvocationContextInitializer.swift
@@ -35,6 +35,7 @@ public protocol SmokeAsyncPerInvocationContextInitializer {
     var handlerSelectorProvider: (() -> SelectorType) { get }
     var operationsInitializer: ((inout SelectorType) -> Void) { get }
     
+    var defaultOperationDelegate: SelectorType.DefaultOperationDelegateType { get }
     var serverName: String { get }
     var invocationStrategy: InvocationStrategy { get }
     var defaultLogger: Logger { get }

--- a/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
@@ -26,6 +26,12 @@ internal struct PingParameters {
     static let payload = "Ping completed.".data(using: .utf8) ?? Data()
 }
 
+public enum RequestExecutor {
+    case originalEventLoop
+    case cooperativeTaskGroup
+    case dispatchQueue(DispatchQueue)
+}
+
 /**
  Implementation of the HttpRequestHandler protocol that handles an
  incoming Http request as an operation.
@@ -46,9 +52,11 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
     let pingOperationReporting: SmokeOperationReporting
     let unknownOperationReporting: SmokeOperationReporting
     let errorDeterminingOperationReporting: SmokeOperationReporting
+    let requestExecutor: RequestExecutor
     
     public init(handlerSelector: SelectorType, context: SelectorType.ContextType, serverName: String,
-         reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer>) {
+                reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer>,
+                requestExecutor: RequestExecutor = .originalEventLoop) {
         self.handlerSelector = handlerSelector
         self.context = .static(context)
         
@@ -59,11 +67,13 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
         self.errorDeterminingOperationReporting = SmokeOperationReporting(serverName: serverName,
                                                                                 request: .errorDeterminingOperation,
                                                                                 configuration: reportingConfiguration)
+        self.requestExecutor = requestExecutor
     }
     
     public init(handlerSelector: SelectorType,
-         contextProvider: @escaping (InvocationReportingType) -> SelectorType.ContextType,
-         serverName: String, reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer>) {
+                contextProvider: @escaping (InvocationReportingType) -> SelectorType.ContextType,
+                serverName: String, reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer>,
+                requestExecutor: RequestExecutor = .originalEventLoop) {
         self.handlerSelector = handlerSelector
         self.context = .provider(contextProvider)
         
@@ -74,30 +84,76 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
         self.errorDeterminingOperationReporting = SmokeOperationReporting(serverName: serverName,
                                                                                 request: .errorDeterminingOperation,
                                                                                 configuration: reportingConfiguration)
+        self.requestExecutor = requestExecutor
+    }
+    
+    private func getInvocationContextForAnonymousRequest(requestReporting: SmokeOperationReporting,
+                                                         requestLogger: Logger,
+                                                         invocationReportingProvider: @escaping (Logger) -> InvocationReportingType)
+    -> SmokeInvocationContext<InvocationReportingType> {
+        var decoratedRequestLogger: Logger = requestLogger
+        handlerSelector.defaultOperationDelegate.decorateLoggerForAnonymousRequest(requestLogger: &decoratedRequestLogger)
+        
+        let invocationReporting = invocationReportingProvider(decoratedRequestLogger)
+        return SmokeInvocationContext(invocationReporting: invocationReporting,
+                                      requestReporting: requestReporting)
+    }
+    
+    public func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
+                       invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String,
+                       invocationReportingProvider: @escaping (Logger) -> InvocationReportingType) {
+        handle(requestHead: requestHead, body: body, responseHandler: responseHandler,
+               invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
+               invocationReportingProvider: invocationReportingProvider,
+               requestStartTraceAction: nil)
     }
 
     public func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                        invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String,
-                       invocationReportingProvider: @escaping (Logger) -> InvocationReportingType) {
-        func getInvocationContextForAnonymousRequest(requestReporting: SmokeOperationReporting)
-                -> SmokeInvocationContext<InvocationReportingType> {
-            var decoratedRequestLogger: Logger = requestLogger
-            handlerSelector.defaultOperationDelegate.decorateLoggerForAnonymousRequest(requestLogger: &decoratedRequestLogger)
-            
-            let invocationReporting = invocationReportingProvider(decoratedRequestLogger)
-            return SmokeInvocationContext(invocationReporting: invocationReporting,
-                                                requestReporting: requestReporting)
-        }
-        
+                       invocationReportingProvider: @escaping (Logger) -> InvocationReportingType,
+                       requestStartTraceAction: (() -> (Logger))?) {
         // this is the ping url
         if requestHead.uri == PingParameters.uri {
             let body = (contentType: "text/plain", data: PingParameters.payload)
             let responseComponents = HTTP1ServerResponseComponents(additionalHeaders: [], body: body)
-            let invocationContext = getInvocationContextForAnonymousRequest(requestReporting: pingOperationReporting)
+            let invocationContext = getInvocationContextForAnonymousRequest(requestReporting: pingOperationReporting,
+                                                                            requestLogger: requestLogger,
+                                                                            invocationReportingProvider: invocationReportingProvider)
             responseHandler.completeSilentlyInEventLoop(invocationContext: invocationContext,
                                                         status: .ok, responseComponents: responseComponents)
             
             return
+        }
+        
+        switch self.requestExecutor {
+        case .cooperativeTaskGroup:
+            Task {
+                handleOnDesiredThreadPool(requestHead: requestHead, body: body, responseHandler: responseHandler,
+                                          invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
+                                          invocationReportingProvider: invocationReportingProvider, requestStartTraceAction: requestStartTraceAction)
+            }
+        case .dispatchQueue(let dispatchQueue):
+            dispatchQueue.async {
+                handleOnDesiredThreadPool(requestHead: requestHead, body: body, responseHandler: responseHandler,
+                                          invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
+                                          invocationReportingProvider: invocationReportingProvider, requestStartTraceAction: requestStartTraceAction)
+            }
+        case .originalEventLoop:
+            handleOnDesiredThreadPool(requestHead: requestHead, body: body, responseHandler: responseHandler,
+                                      invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
+                                      invocationReportingProvider: invocationReportingProvider, requestStartTraceAction: requestStartTraceAction)
+        }
+    }
+    
+    private func handleOnDesiredThreadPool(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
+                                           invocationStrategy: InvocationStrategy, requestLogger originalLogger: Logger, internalRequestId: String,
+                                           invocationReportingProvider: @escaping (Logger) -> InvocationReportingType,
+                                           requestStartTraceAction: (() -> (Logger))?) {
+        let requestLogger: Logger
+        if let requestStartTraceAction = requestStartTraceAction {
+            requestLogger = requestStartTraceAction()
+        } else {
+            requestLogger = originalLogger
         }
         
         let uriComponents = requestHead.uri.split(separator: "?", maxSplits: 1)
@@ -119,7 +175,9 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
                                                               query: query,
                                                               pathShape: .null)
             
-            let invocationContext = getInvocationContextForAnonymousRequest(requestReporting: unknownOperationReporting)
+            let invocationContext = getInvocationContextForAnonymousRequest(requestReporting: unknownOperationReporting,
+                                                                            requestLogger: requestLogger,
+                                                                            invocationReportingProvider: invocationReportingProvider)
             defaultOperationDelegate.handleResponseForInvalidOperation(
                 requestHead: smokeHTTP1RequestHead,
                 message: reason,
@@ -133,7 +191,9 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
                                                               query: query,
                                                               pathShape: .null)
             
-            let invocationContext = getInvocationContextForAnonymousRequest(requestReporting: errorDeterminingOperationReporting)
+            let invocationContext = getInvocationContextForAnonymousRequest(requestReporting: errorDeterminingOperationReporting,
+                                                                            requestLogger: requestLogger,
+                                                                            invocationReportingProvider: invocationReportingProvider)
             defaultOperationDelegate.handleResponseForInternalServerError(
                 requestHead: smokeHTTP1RequestHead,
                 responseHandler: responseHandler,

--- a/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
@@ -29,7 +29,7 @@ internal struct PingParameters {
 public enum RequestExecutor {
     case originalEventLoop
     case cooperativeTaskGroup
-    case dispatchQueue(DispatchQueue)
+    case dispatchQueue
 }
 
 /**
@@ -132,8 +132,8 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
                                           invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
                                           invocationReportingProvider: invocationReportingProvider, requestStartTraceAction: requestStartTraceAction)
             }
-        case .dispatchQueue(let dispatchQueue):
-            dispatchQueue.async {
+        case .dispatchQueue:
+            DispatchQueue.global().async {
                 handleOnDesiredThreadPool(requestHead: requestHead, body: body, responseHandler: responseHandler,
                                           invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
                                           invocationReportingProvider: invocationReportingProvider, requestStartTraceAction: requestStartTraceAction)

--- a/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerPerInvocationContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerPerInvocationContextInitializer.swift
@@ -26,6 +26,7 @@ public protocol SmokeAsyncServerPerInvocationContextInitializer: SmokeAsyncPerIn
     var port: Int { get }
     var shutdownOnSignals: [SmokeHTTP1Server.ShutdownOnSignal] { get }
     var eventLoopProvider: SmokeHTTP1Server.EventLoopProvider { get }
+    var internalExecutor: InternalExecutor { get }
 }
 
 public extension SmokeAsyncServerPerInvocationContextInitializer {
@@ -39,6 +40,10 @@ public extension SmokeAsyncServerPerInvocationContextInitializer {
     
     var eventLoopProvider: SmokeHTTP1Server.EventLoopProvider {
         return .spawnNewThreads
+    }
+    
+    var internalExecutor: InternalExecutor {
+        return .eventLoop
     }
 }
 #endif

--- a/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerPerInvocationContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerPerInvocationContextInitializer.swift
@@ -26,7 +26,7 @@ public protocol SmokeAsyncServerPerInvocationContextInitializer: SmokeAsyncPerIn
     var port: Int { get }
     var shutdownOnSignals: [SmokeHTTP1Server.ShutdownOnSignal] { get }
     var eventLoopProvider: SmokeHTTP1Server.EventLoopProvider { get }
-    var internalExecutor: InternalExecutor { get }
+    var requestExecutor: RequestExecutor { get }
 }
 
 public extension SmokeAsyncServerPerInvocationContextInitializer {
@@ -42,8 +42,8 @@ public extension SmokeAsyncServerPerInvocationContextInitializer {
         return .spawnNewThreads
     }
     
-    var internalExecutor: InternalExecutor {
-        return .eventLoop
+    var requestExecutor: RequestExecutor {
+        return .originalEventLoop
     }
 }
 #endif

--- a/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerStaticContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerStaticContextInitializer.swift
@@ -26,7 +26,7 @@ public protocol SmokeAsyncServerStaticContextInitializer: SmokeAsyncStaticContex
     var port: Int { get }
     var shutdownOnSignals: [SmokeHTTP1Server.ShutdownOnSignal] { get }
     var eventLoopProvider: SmokeHTTP1Server.EventLoopProvider { get }
-    var internalExecutor: InternalExecutor { get }
+    var requestExecutor: RequestExecutor { get }
 }
 
 public extension SmokeAsyncServerStaticContextInitializer {
@@ -42,8 +42,8 @@ public extension SmokeAsyncServerStaticContextInitializer {
         return .spawnNewThreads
     }
     
-    var internalExecutor: InternalExecutor {
-        return .eventLoop
+    var requestExecutor: RequestExecutor {
+        return .originalEventLoop
     }
 }
 #endif

--- a/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerStaticContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerStaticContextInitializer.swift
@@ -26,6 +26,7 @@ public protocol SmokeAsyncServerStaticContextInitializer: SmokeAsyncStaticContex
     var port: Int { get }
     var shutdownOnSignals: [SmokeHTTP1Server.ShutdownOnSignal] { get }
     var eventLoopProvider: SmokeHTTP1Server.EventLoopProvider { get }
+    var internalExecutor: InternalExecutor { get }
 }
 
 public extension SmokeAsyncServerStaticContextInitializer {
@@ -39,6 +40,10 @@ public extension SmokeAsyncServerStaticContextInitializer {
     
     var eventLoopProvider: SmokeHTTP1Server.EventLoopProvider {
         return .spawnNewThreads
+    }
+    
+    var internalExecutor: InternalExecutor {
+        return .eventLoop
     }
 }
 #endif

--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
@@ -25,11 +25,6 @@ import NIO
 import AsyncHTTPClient
 import SmokeInvocation
 
-public enum InternalExecutor {
-    case eventLoop
-    case dispatchQueue
-}
-
 public extension SmokeHTTP1Server {
     @available(swift, deprecated: 3.0, message: "Provide an initializer that accepts an EventLoopGroup instance.")
     static func runAsOperationServer<InitializerType: SmokeServerStaticContextInitializer, TraceContextType>(
@@ -354,26 +349,13 @@ public extension SmokeHTTP1Server {
         
         var handlerSelector = initalizer.handlerSelectorProvider()
         initalizer.operationsInitializer(&handlerSelector)
-                
-        let requestExecutor: RequestExecutor
-        switch initalizer.internalExecutor {
-        case .eventLoop:
-            requestExecutor = .originalEventLoop
-        case .dispatchQueue:
-            let executorQueue = DispatchQueue(
-                        label: "com.amazon.SmokeFramework.executorQueue",
-                        attributes: [.concurrent],
-                        target: DispatchQueue.global())
-            
-            requestExecutor = .dispatchQueue(executorQueue)
-        }
         
         let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
             handlerSelector: handlerSelector,
             context: initalizer.getInvocationContext(),
             serverName: initalizer.serverName,
             reportingConfiguration: initalizer.reportingConfiguration,
-            requestExecutor: requestExecutor)
+            requestExecutor: initalizer.requestExecutor)
         let server = StandardSmokeHTTP1Server(handler: handler,
                                               port: initalizer.port,
                                               invocationStrategy: initalizer.invocationStrategy,
@@ -429,26 +411,13 @@ public extension SmokeHTTP1Server {
         
         var handlerSelector = initalizer.handlerSelectorProvider()
         initalizer.operationsInitializer(&handlerSelector)
-                
-        let requestExecutor: RequestExecutor
-        switch initalizer.internalExecutor {
-        case .eventLoop:
-            requestExecutor = .originalEventLoop
-        case .dispatchQueue:
-            let executorQueue = DispatchQueue(
-                        label: "com.amazon.SmokeFramework.executorQueue",
-                        attributes: [.concurrent],
-                        target: DispatchQueue.global())
-            
-            requestExecutor = .dispatchQueue(executorQueue)
-        }
         
         let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
             handlerSelector: handlerSelector,
             contextProvider: initalizer.getInvocationContext,
             serverName: initalizer.serverName,
             reportingConfiguration: initalizer.reportingConfiguration,
-            requestExecutor: requestExecutor)
+            requestExecutor: initalizer.requestExecutor)
         let server = StandardSmokeHTTP1Server(handler: handler,
                                               port: initalizer.port,
                                               invocationStrategy: initalizer.invocationStrategy,

--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
@@ -25,6 +25,11 @@ import NIO
 import AsyncHTTPClient
 import SmokeInvocation
 
+public enum InternalExecutor {
+    case eventLoop
+    case dispatchQueue
+}
+
 public extension SmokeHTTP1Server {
     @available(swift, deprecated: 3.0, message: "Provide an initializer that accepts an EventLoopGroup instance.")
     static func runAsOperationServer<InitializerType: SmokeServerStaticContextInitializer, TraceContextType>(
@@ -349,12 +354,26 @@ public extension SmokeHTTP1Server {
         
         var handlerSelector = initalizer.handlerSelectorProvider()
         initalizer.operationsInitializer(&handlerSelector)
+                
+        let requestExecutor: RequestExecutor
+        switch initalizer.internalExecutor {
+        case .eventLoop:
+            requestExecutor = .originalEventLoop
+        case .dispatchQueue:
+            let executorQueue = DispatchQueue(
+                        label: "com.amazon.SmokeFramework.executorQueue",
+                        attributes: [.concurrent],
+                        target: DispatchQueue.global())
+            
+            requestExecutor = .dispatchQueue(executorQueue)
+        }
         
         let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
             handlerSelector: handlerSelector,
             context: initalizer.getInvocationContext(),
             serverName: initalizer.serverName,
-            reportingConfiguration: initalizer.reportingConfiguration)
+            reportingConfiguration: initalizer.reportingConfiguration,
+            requestExecutor: requestExecutor)
         let server = StandardSmokeHTTP1Server(handler: handler,
                                               port: initalizer.port,
                                               invocationStrategy: initalizer.invocationStrategy,
@@ -410,12 +429,26 @@ public extension SmokeHTTP1Server {
         
         var handlerSelector = initalizer.handlerSelectorProvider()
         initalizer.operationsInitializer(&handlerSelector)
+                
+        let requestExecutor: RequestExecutor
+        switch initalizer.internalExecutor {
+        case .eventLoop:
+            requestExecutor = .originalEventLoop
+        case .dispatchQueue:
+            let executorQueue = DispatchQueue(
+                        label: "com.amazon.SmokeFramework.executorQueue",
+                        attributes: [.concurrent],
+                        target: DispatchQueue.global())
+            
+            requestExecutor = .dispatchQueue(executorQueue)
+        }
         
         let handler = OperationServerHTTP1RequestHandler<InitializerType.SelectorType, TraceContextType>(
             handlerSelector: handlerSelector,
             contextProvider: initalizer.getInvocationContext,
             serverName: initalizer.serverName,
-            reportingConfiguration: initalizer.reportingConfiguration)
+            reportingConfiguration: initalizer.reportingConfiguration,
+            requestExecutor: requestExecutor)
         let server = StandardSmokeHTTP1Server(handler: handler,
                                               port: initalizer.port,
                                               invocationStrategy: initalizer.invocationStrategy,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Provides the option to move serialisation and deserialisation of the request and response bodies off the event loop (which could become contended with large request or response bodies due to the limited number of loops) and onto threads managed by the global dispatch queue (which can expand as needed). This reduces contention for the event loops under these circumstances and provides more stable worse-case latencies.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
