### PR TITLE
Report requestReadLatencyMS and decorate logger with incomingOperation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ struct MyPerInvocationContextInitializer: StandardJSONSmokeServerPerInvocationCo
             successCounterMatchingRequests: .none,
             failure5XXCounterMatchingRequests: .onlyForOperations([.theOperation]),
             failure4XXCounterMatchingRequests: .exceptForOperations([.theOperation]),
+            requestReadLatencyTimerMatchingRequests: .none,
             latencyTimerMatchingRequests: .all,
             serviceLatencyTimerMatchingRequests: .all,
             outwardServiceCallLatencyTimerMatchingRequests: .all,

--- a/Sources/SmokeHTTP1/SmokeInwardsRequestContext.swift
+++ b/Sources/SmokeHTTP1/SmokeInwardsRequestContext.swift
@@ -19,6 +19,8 @@ import Foundation
 import SmokeHTTPClient
 
 public protocol SmokeInwardsRequestContext {
+    var headReceiveDate: Date? { get }
+    
     var requestStart: Date { get }
     
     var retriableOutputRequestRecords: [RetriableOutputRequestRecord] { get }
@@ -26,7 +28,14 @@ public protocol SmokeInwardsRequestContext {
     var retryAttemptRecords: [RetryAttemptRecord] { get }
 }
 
+public extension SmokeInwardsRequestContext {
+    var headReceiveDate: Date? {
+        return nil
+    }
+}
+
 internal class StandardSmokeInwardsRequestContext: SmokeInwardsRequestContext, OutwardsRequestAggregator {
+    let headReceiveDate: Date?
     let requestStart: Date
     private(set) var retriableOutputRequestRecords: [RetriableOutputRequestRecord]
     private(set) var retryAttemptRecords: [RetryAttemptRecord]
@@ -35,7 +44,8 @@ internal class StandardSmokeInwardsRequestContext: SmokeInwardsRequestContext, O
                 label: "com.amazon.SmokeFramework.StandardSmokeInwardsRequestContext.accessQueue",
                 target: DispatchQueue.global())
     
-    init(requestStart: Date) {
+    init(headReceiveDate: Date?, requestStart: Date) {
+        self.headReceiveDate = headReceiveDate
         self.requestStart = requestStart
         self.retriableOutputRequestRecords = []
         self.retryAttemptRecords = []

--- a/Sources/SmokeOperations/OperationHandler.swift
+++ b/Sources/SmokeOperations/OperationHandler.swift
@@ -19,6 +19,8 @@ import Foundation
 import Logging
 import SmokeInvocation
 
+private let incomingOperationKey = "incomingOperation"
+
 /**
  Struct that handles serialization and de-serialization of request and response
  bodies from and to the shapes required by operation handlers.
@@ -44,8 +46,11 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
                        responseHandler: ResponseHandlerType, invocationStrategy: InvocationStrategy,
                        requestLogger: Logger, internalRequestId: String,
                        invocationReportingProvider: @escaping (Logger) -> InvocationReportingType) {
+        var decoratedRequestLogger = requestLogger
+        decoratedRequestLogger[metadataKey: incomingOperationKey] = "\(self.operationIdentifer)"
+        
         return operationFunction(requestHead, body, context, responseHandler,
-                                 invocationStrategy, requestLogger, internalRequestId, invocationReportingProvider)
+                                 invocationStrategy, decoratedRequestLogger, internalRequestId, invocationReportingProvider)
     }
     
     private enum InputDecodeResult<InputType: Validatable> {

--- a/Sources/SmokeOperations/SmokeOperationReporting.swift
+++ b/Sources/SmokeOperations/SmokeOperationReporting.swift
@@ -25,6 +25,7 @@ private let metricNameDimension = "Metric Name"
 private let successCountMetric = "successCount"
 private let failure5XXCountMetric = "failure5XXCount"
 private let failure4XXCountMetric = "failure4XXCount"
+private let requestReadLatencyTimeMetric = "requestReadLatencyTime"
 private let specificFailureStatusCountMetricFormat = "failure%dCount"
 private let latencyTimeMetric = "latencyTime"
 private let serviceLatencyTimeMetric = "serviceLatencyTime"
@@ -38,6 +39,7 @@ public struct SmokeOperationReporting {
     public let successCounter: Metrics.Counter?
     public let failure5XXCounter: Metrics.Counter?
     public let failure4XXCounter: Metrics.Counter?
+    public let requestReadLatencyTimer: Metrics.Timer?
     public let specificFailureStatusCounters: [UInt: Metrics.Counter]?
     public let latencyTimer: Metrics.Timer?
     public let serviceLatencyTimer: Metrics.Timer?
@@ -80,6 +82,12 @@ public struct SmokeOperationReporting {
             failure4XXCounter = getCounter(metricName: failure4XXCountMetric)
         } else {
             failure4XXCounter = nil
+        }
+        
+        if configuration.reportRequestReadLatencyForRequest(request) {
+            requestReadLatencyTimer = getTimer(metricName: requestReadLatencyTimeMetric)
+        } else {
+            requestReadLatencyTimer = nil
         }
         
         if configuration.reportSpecificFailureStatusesForRequest(request),

--- a/Sources/SmokeOperations/SmokeReportingConfiguration.swift
+++ b/Sources/SmokeOperations/SmokeReportingConfiguration.swift
@@ -84,6 +84,7 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
     private let successCounterMatchingRequests: MatchingRequests
     private let failure5XXCounterMatchingRequests: MatchingRequests
     private let failure4XXCounterMatchingRequests: MatchingRequests
+    private let requestReadLatencyTimerMatchingRequests: MatchingRequests
     private let specificFailureStatusCounterMatchingRequests: MatchingRequests
     private let latencyTimerMatchingRequests: MatchingRequests
     
@@ -95,6 +96,7 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
     public init(successCounterMatchingRequests: MatchingRequests,
                 failure5XXCounterMatchingRequests: MatchingRequests,
                 failure4XXCounterMatchingRequests: MatchingRequests,
+                requestReadLatencyTimerMatchingRequests: MatchingRequests = .none,
                 latencyTimerMatchingRequests: MatchingRequests,
                 serviceLatencyTimerMatchingRequests: MatchingRequests = .none,
                 outwardServiceCallLatencyTimerMatchingRequests: MatchingRequests = .none,
@@ -102,6 +104,7 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
         self.successCounterMatchingRequests = successCounterMatchingRequests
         self.failure5XXCounterMatchingRequests = failure5XXCounterMatchingRequests
         self.failure4XXCounterMatchingRequests = failure4XXCounterMatchingRequests
+        self.requestReadLatencyTimerMatchingRequests = requestReadLatencyTimerMatchingRequests
         self.latencyTimerMatchingRequests = latencyTimerMatchingRequests
         self.serviceLatencyTimerMatchingRequests = serviceLatencyTimerMatchingRequests
         self.outwardServiceCallLatencySumTimerMatchingRequests = outwardServiceCallLatencyTimerMatchingRequests
@@ -115,6 +118,7 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
                 failure4XXCounterMatchingRequests: MatchingRequests,
                 specificFailureStatusCounterMatchingRequests: MatchingRequests,
                 specificFailureStatusesToReport: Set<UInt>,
+                requestReadLatencyTimerMatchingRequests: MatchingRequests = .none,
                 latencyTimerMatchingRequests: MatchingRequests,
                 serviceLatencyTimerMatchingRequests: MatchingRequests = .none,
                 outwardServiceCallLatencyTimerMatchingRequests: MatchingRequests = .none,
@@ -122,6 +126,7 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
         self.successCounterMatchingRequests = successCounterMatchingRequests
         self.failure5XXCounterMatchingRequests = failure5XXCounterMatchingRequests
         self.failure4XXCounterMatchingRequests = failure4XXCounterMatchingRequests
+        self.requestReadLatencyTimerMatchingRequests = requestReadLatencyTimerMatchingRequests
         self.latencyTimerMatchingRequests = latencyTimerMatchingRequests
         self.serviceLatencyTimerMatchingRequests = serviceLatencyTimerMatchingRequests
         self.outwardServiceCallLatencySumTimerMatchingRequests = outwardServiceCallLatencyTimerMatchingRequests
@@ -130,10 +135,13 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
         self.specificFailureStatusesToReport = specificFailureStatusesToReport
     }
     
+    // Metrics added within the current major version are set to .none
+    // to maintain existing behaviour
     public init(matchingRequests: MatchingRequests = MatchingRequests()) {
         self.successCounterMatchingRequests = matchingRequests
         self.failure5XXCounterMatchingRequests = matchingRequests
         self.failure4XXCounterMatchingRequests = matchingRequests
+        self.requestReadLatencyTimerMatchingRequests = .none
         self.latencyTimerMatchingRequests = matchingRequests
         self.serviceLatencyTimerMatchingRequests = .none
         self.outwardServiceCallLatencySumTimerMatchingRequests = .none
@@ -152,6 +160,10 @@ public struct SmokeReportingConfiguration<OperationIdentifer: OperationIdentity>
     
     public func reportFailure4XXForRequest(_ request: RequestType<OperationIdentifer>) -> Bool {
         return isMatchingRequest(request, matchingRequests: failure4XXCounterMatchingRequests)
+    }
+    
+    public func reportRequestReadLatencyForRequest(_ request: RequestType<OperationIdentifer>) -> Bool {
+        return isMatchingRequest(request, matchingRequests: requestReadLatencyTimerMatchingRequests)
     }
     
     public func reportSpecificFailureStatusesForRequest(_ request: RequestType<OperationIdentifer>) -> Bool {

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -63,14 +63,26 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
         
         // get the request id if present
         if !requestIds.isEmpty {
-            self.externalRequestId = requestIds.joined(separator: ",")
+            let joinedExternalRequestId = requestIds.joined(separator: ",")
+            
+            if joinedExternalRequestId != "none" {
+                self.externalRequestId = joinedExternalRequestId
+            } else {
+                self.externalRequestId = nil
+            }
         } else {
             self.externalRequestId = nil
         }
         
         // get the trace id if present
         if !traceIds.isEmpty {
-            self.traceId = traceIds.joined(separator: ",")
+            let joinedTraceId = traceIds.joined(separator: ",")
+            
+            if joinedTraceId != "none" {
+                self.traceId = joinedTraceId
+            } else {
+                self.traceId = nil
+            }
         } else {
             self.traceId = nil
         }
@@ -193,15 +205,11 @@ extension SmokeInvocationTraceContext: InvocationTraceContext {
         }
         
         if let requestIds = response?.headers[requestIdHeader], !requestIds.isEmpty {
-            requestIds.enumerated().forEach { (index, header) in
-                logMetadata["\(requestIdHeader)(index)"] = "\(header)"
-            }
+            logMetadata[requestIdHeader] = "\(requestIds.joined(separator: ","))"
         }
         
         if let traceIds = response?.headers[traceIdHeader], !traceIds.isEmpty {
-            traceIds.enumerated().forEach { (index, header) in
-                logMetadata["\(traceIdHeader)(index)"] = "\(header)"
-            }
+            logMetadata[traceIdHeader] = "\(traceIds.joined(separator: ","))"
         }
         
         if let bodyData = bodyData {

--- a/Sources/SmokeOperationsHTTP1Server/HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeOperationsHTTP1Server/HTTP1RequestInvocationContext.swift
@@ -27,6 +27,7 @@ public protocol HTTP1RequestInvocationContext {
     var successCounter: Metrics.Counter? { get }
     var failure5XXCounter: Metrics.Counter? { get }
     var failure4XXCounter: Metrics.Counter? { get }
+    var requestReadLatencyTimer: Metrics.Timer? { get }
     var specificFailureStatusCounters: [UInt: Metrics.Counter]? { get }
     var latencyTimer: Metrics.Timer? { get }
     var serviceLatencyTimer: Metrics.Timer? { get }
@@ -48,6 +49,10 @@ public extension HTTP1RequestInvocationContext {
     }
     
     var failure4XXCounter: Metrics.Counter? {
+        return nil
+    }
+    
+    var requestReadLatencyTimer: Metrics.Timer? {
         return nil
     }
     

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationContext+HTTP1RequestInvocationContext.swift
@@ -42,6 +42,10 @@ extension SmokeInvocationContext: HTTP1RequestInvocationContext where
     public var failure4XXCounter: Metrics.Counter? {
         return self.requestReporting.failure4XXCounter
     }
+        
+    public var requestReadLatencyTimer: Metrics.Timer? {
+        return self.requestReporting.requestReadLatencyTimer
+    }
     
     public var specificFailureStatusCounters: [UInt: Metrics.Counter]? {
         return self.requestReporting.specificFailureStatusCounters

--- a/Sources/SmokeOperationsHTTP1Server/StandardHTTP1ResponseHandler.swift
+++ b/Sources/SmokeOperationsHTTP1Server/StandardHTTP1ResponseHandler.swift
@@ -147,12 +147,17 @@ public struct StandardHTTP1ResponseHandler<
                 return requestRecord.outputRequests.count > 1
             }
             
-            let logMetadata: Logger.Metadata = [
+            var logMetadata: Logger.Metadata = [
                 "requestLatencyMS": "\(requestLatency)",
                 "serviceCallCount":"\(serviceCallCount)",
                 "serviceCallLatencyMS": "\(serviceCallLatency)",
                 "retryServiceCallCount": "\(retriedServiceCalls.count)",
                 "retryWaitLatencyMS": "\(retryWaitLatency)"]
+            
+            if let headReceiveDate = smokeInwardsRequestContext.headReceiveDate {
+                let requestReadLatency = smokeInwardsRequestContext.requestStart.timeIntervalSince(headReceiveDate).milliseconds
+                logMetadata["requestReadLatencyMS"] = "\(requestReadLatency)"
+            }
             
             invocationContext.logger.info("Inwards request complete.", metadata: logMetadata)
             

--- a/Sources/SmokeOperationsHTTP1Server/StandardHTTP1ResponseHandler.swift
+++ b/Sources/SmokeOperationsHTTP1Server/StandardHTTP1ResponseHandler.swift
@@ -157,6 +157,8 @@ public struct StandardHTTP1ResponseHandler<
             if let headReceiveDate = smokeInwardsRequestContext.headReceiveDate {
                 let requestReadLatency = smokeInwardsRequestContext.requestStart.timeIntervalSince(headReceiveDate).milliseconds
                 logMetadata["requestReadLatencyMS"] = "\(requestReadLatency)"
+                
+                invocationContext.requestReadLatencyTimer?.recordMilliseconds(requestReadLatency)
             }
             
             invocationContext.logger.info("Inwards request complete.", metadata: logMetadata)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Emit "requestReadLatencyMS" in the response summary and add a corresponding metric to indicate how long from when the request head was received until the request was complete and the operation could be handled.
2. Decorate the operation logger with the Operation using the `incomingOperation` metadata key.
3. Combine multiple request headers into a single log metadata entry
4. Ignore headers with value "none"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
