### PR TITLE
Limit prettyPrinted JSON to the debug build

### DIFF
--- a/Sources/SmokeOperations/JSONEncoder+getFrameworkEncoder.swift
+++ b/Sources/SmokeOperations/JSONEncoder+getFrameworkEncoder.swift
@@ -24,7 +24,9 @@ private func createEncoder() -> JSONEncoder {
         jsonEncoder.dateEncodingStrategy = .iso8601
     }
 
-    jsonEncoder.outputFormatting = .prettyPrinted
+    #if DEBUG
+        jsonEncoder.outputFormatting = .prettyPrinted
+    #endif
     
     return jsonEncoder
 }


### PR DESCRIPTION
*Issue #, if available:*
AWS API Gateway has a response limit of 10MB. This will help with that by avoiding sending white space.

*Description of changes:*
Moved pretty printed JSON to be available in DEBUG builds only.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
