### PR TITLE
Integrate apple/swift-distributed-tracing.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        swift: ["5.7.2"]
+        swift: ["5.8"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.21.0
+      - uses: swift-actions/setup-swift@v1.23.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -28,10 +28,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.6.3", "5.5.3"]
+        swift: ["5.7.3", "5.6.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.21.0
+      - uses: swift-actions/setup-swift@v1.23.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "fc510a39cff61b849bf5cdff17eb2bd6d0777b49",
-          "version": "1.11.5"
+          "revision": "333e60cc90f52973f7ee29cd8e3a7f6adfe79f4e",
+          "version": "1.17.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "c14d4dee028a1aa0b316ec194ec15876f86fbcd9",
-          "version": "2.14.0"
+          "revision": "f0a8debc8048afd30540ea3f2c80e3486530aa17",
+          "version": "2.19.1"
         }
       },
       {
@@ -24,8 +24,26 @@
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
           "branch": null,
-          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
-          "version": "1.0.2"
+          "revision": "6c89474e62719ddcc1e9614989fff2f68208fe10",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "swift-distributed-tracing",
+        "repositoryURL": "https://github.com/apple/swift-distributed-tracing.git",
+        "state": {
+          "branch": null,
+          "revision": "ba07967bb775ed8aa73c46ab731c85b9fb613305",
+          "version": "1.0.0"
         }
       },
       {
@@ -33,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
-          "version": "1.4.4"
+          "revision": "32e8d724467f8fe623624570367e3d50c5638e46",
+          "version": "1.5.2"
         }
       },
       {
@@ -42,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "53be78637ecd165d1ddedc4e20de69b8f43ec3b7",
-          "version": "2.3.2"
+          "revision": "e8bced74bc6d747745935e469f45d03f048d6cbd",
+          "version": "2.3.4"
         }
       },
       {
@@ -51,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "b4e0a274f7f34210e97e2f2c50ab02a10b549250",
-          "version": "2.41.1"
+          "revision": "2d8e6ca36fe3e8ed74b0883f593757a45463c34d",
+          "version": "2.53.0"
         }
       },
       {
@@ -60,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "a75e92bde3683241c15df3dd905b7a6dcac4d551",
-          "version": "1.12.1"
+          "revision": "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
+          "version": "1.19.0"
         }
       },
       {
@@ -69,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "f9ab1c94c80d568efd762d2a638f25162691d766",
-          "version": "1.22.1"
+          "revision": "6d021a48483dbb273a9be43f65234bdc9185b364",
+          "version": "1.26.0"
         }
       },
       {
@@ -78,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "0265283d3539ced108b9b8287eb3328c9d85acdc",
-          "version": "2.21.0"
+          "revision": "e866a626e105042a6a72a870c88b4c531ba05f83",
+          "version": "2.24.0"
         }
       },
       {
@@ -87,8 +105,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "4e02d9cf35cabfb538c96613272fb027dd0c8692",
-          "version": "1.13.1"
+          "revision": "41f4098903878418537020075a4d8a6e20a0b182",
+          "version": "1.17.0"
+        }
+      },
+      {
+        "package": "swift-service-context",
+        "repositoryURL": "https://github.com/apple/swift-service-context.git",
+        "state": {
+          "branch": null,
+          "revision": "ce0141c8f123132dbd02fd45fea448018762df1b",
+          "version": "1.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
         .package(url: "https://github.com/amzn/smoke-http.git", from: "2.14.0"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -75,6 +76,7 @@ let package = Package(
             name: "SmokeOperations", dependencies: [
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
                 .target(name: "SmokeInvocation"),
             ]),
         .target(

--- a/README.md
+++ b/README.md
@@ -289,6 +289,22 @@ struct MyPerInvocationContextInitializer: StandardJSONSmokeServerPerInvocationCo
 SmokeHTTP1Server.runAsOperationServer(MyPerInvocationContextInitializer.init)
 ```
 
+# Enabling Distributed Tracing
+
+To have your application participate in distributed traces, add a property `enableTracingWithSwiftConcurrency` 
+with a value of true to your application initializer.
+
+```swift
+struct MyPerInvocationContextInitializer: StandardJSONSmokeServerPerInvocationContextInitializer {
+    let enableTracingWithSwiftConcurrency = true
+
+    ...
+}
+```
+
+This will enable tracing for any operation handlers that use Swift Concurrency (async/await). You will also 
+need to setup an Instrumentation backend by following the instructions [here](https://swiftpackageindex.com/apple/swift-distributed-tracing/1.0.0/documentation/tracing/traceyourapplication).
+
 # Further Concepts
 
 ## The Application Context

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-framework/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.5|5.6|5.7-orange.svg?style=flat" alt="Swift 5.5, 5.6 and 5.7 Tested">
+<img src="https://img.shields.io/badge/swift-5.6|5.7|5.8-orange.svg?style=flat" alt="Swift 5.6, 5.7 and 5.8 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-5.6|5.7|5.8-orange.svg?style=flat" alt="Swift 5.6, 5.7 and 5.8 Tested">
 </a>
-<img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04 and 20.04 Tested">
+<img src="https://img.shields.io/badge/ubuntu-20.04|22.04-yellow.svg?style=flat" alt="Ubuntu 20.04 and 22.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">
 <img src="https://img.shields.io/badge/AmazonLinux-2-yellow.svg?style=flat" alt="Amazon Linux 2 Tested">
 <a href="https://gitter.im/SmokeServerSide">
@@ -289,7 +289,7 @@ struct MyPerInvocationContextInitializer: StandardJSONSmokeServerPerInvocationCo
 SmokeHTTP1Server.runAsOperationServer(MyPerInvocationContextInitializer.init)
 ```
 
-# Enabling Distributed Tracing
+# Enabling Distributed Tracing (Swift 5.7 and greater)
 
 To have your application participate in distributed traces, add a property `enableTracingWithSwiftConcurrency` 
 with a value of true to your application initializer.

--- a/Sources/SmokeOperations/InvocationReporting.swift
+++ b/Sources/SmokeOperations/InvocationReporting.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import Logging
+import Tracing
 
 /**
  A protocol that can report on an invocation.
@@ -24,4 +25,12 @@ import Logging
 public protocol InvocationReporting {
     var logger: Logger { get }
     var internalRequestId: String { get }
+    var span: Span? { get }
+}
+
+public extension InvocationReporting {
+    // Add span property while remaining backwards compatible
+    var span: Span? {
+        return nil
+    }
 }

--- a/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import Logging
+import Tracing
 
 public extension OperationHandler {
     /**
@@ -57,8 +58,15 @@ public extension OperationHandler {
             Task {
                 let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
                 do {
-                    let output = try await operation(input, context, invocationContext.invocationReporting)
-                    
+                    let output: OutputType
+                    if let span = invocationContext.invocationReporting.span {
+                        output = try await ServiceContext.withValue(span.context) {
+                            return try await operation(input, context, invocationContext.invocationReporting)
+                        }
+                    } else {
+                        output = try await operation(input, context, invocationContext.invocationReporting)
+                    }
+                                        
                     handlerResult = .success(output)
                 } catch let smokeReturnableError as SmokeReturnableError {
                     handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)

--- a/Sources/SmokeOperations/OperationHandler+withInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withInputWithOutput.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import Logging
+import Tracing
 
 public extension OperationHandler {
     /**
@@ -61,7 +62,14 @@ public extension OperationHandler {
             Task {
                 let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
                 do {
-                    let output = try await operation(input, context)
+                    let output: OutputType
+                    if let span = invocationContext.invocationReporting.span {
+                        output = try await ServiceContext.withValue(span.context) {
+                            return try await operation(input, context)
+                        }
+                    } else {
+                        output = try await operation(input, context)
+                    }
                     
                     handlerResult = .success(output)
                 } catch let smokeReturnableError as SmokeReturnableError {

--- a/Sources/SmokeOperations/OperationTraceContext.swift
+++ b/Sources/SmokeOperations/OperationTraceContext.swift
@@ -17,16 +17,61 @@
 
 import Foundation
 import Logging
+import Tracing
+
+public struct RequestSpanParameters {
+    public let operationName: String
+    
+    public init(operationName: String) {
+        self.operationName = operationName
+    }
+}
+
+public enum CreateRequestSpan {
+    // A `Tracing.Span` should never be created for a request.
+    case never
+    // A `Tracing.Span` can be created for a request
+    // if the `OperationTraceContext` decides to create one.
+    // It is the responsibility of the OperationTraceContext
+    // to manage the lifecycle of the span if it creates one,
+    // most likely closing it in the
+    // `handleInwardsRequestComplete` function.
+    case ifRequired(RequestSpanParameters)
+}
+
+public struct OperationTraceContextOptions {
+    public let createRequestSpan: CreateRequestSpan
+   
+    public init(createRequestSpan: CreateRequestSpan) {
+        self.createRequestSpan = createRequestSpan
+    }
+}
 
 public protocol OperationTraceContext {
     associatedtype RequestHeadType
     associatedtype ResponseHeadersType
     associatedtype ResponseStatusType
     
+    var span: Span? { get }
+    
     init(requestHead: RequestHeadType, bodyData: Data?)
+    
+    init(requestHead: RequestHeadType, bodyData: Data?, options: OperationTraceContextOptions?)
     
     func handleInwardsRequestStart(requestHead: RequestHeadType, bodyData: Data?, logger: inout Logger, internalRequestId: String)
     
     func handleInwardsRequestComplete(httpHeaders: inout ResponseHeadersType, status: ResponseStatusType, body: (contentType: String, data: Data)?,
                                       logger: Logger, internalRequestId: String)
+}
+
+public extension OperationTraceContext {
+    // Add options accepting initializer while remaining backwards compatible
+    init(requestHead: RequestHeadType, bodyData: Data?, options: OperationTraceContextOptions?) {
+        self.init(requestHead: requestHead, bodyData: bodyData)
+    }
+    
+    // Add span property while remaining backwards compatible
+    var span: Span? {
+        return nil
+    }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -20,6 +20,12 @@ import SmokeHTTPClient
 import SmokeOperations
 import NIOHTTP1
 import AsyncHTTPClient
+import Tracing
+
+private enum OperationFailure: Error {
+    case withResponseBody(String)
+    case withNoResponseBody
+}
 
 private extension Data {
     var debugString: String {
@@ -48,16 +54,23 @@ public struct SmokeInvocationTraceContext {
     private let externalRequestId: String?
     private let traceId: String?
     
+    public let span: Span?
+    
     public init(externalRequestId: String? = nil,
-                traceId: String? = nil) {
+                traceId: String? = nil,
+                span: Span? = nil) {
         self.externalRequestId = externalRequestId
         self.traceId = traceId
+        self.span = span
     }
 }
 
 extension SmokeInvocationTraceContext: OperationTraceContext {
-    
     public init(requestHead: HTTPRequestHead, bodyData: Data?) {
+        self.init(requestHead: requestHead, bodyData: bodyData, options: nil)
+    }
+    
+    public init(requestHead: NIOHTTP1.HTTPRequestHead, bodyData: Data?, options: OperationTraceContextOptions?) {
         let requestIds = requestHead.headers[requestIdHeader]
         let traceIds = requestHead.headers[traceIdHeader]
         
@@ -86,6 +99,29 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
         } else {
             self.traceId = nil
         }
+        
+        if case .ifRequired(let parameters) = options?.createRequestSpan {
+            var serviceContext = ServiceContext.current ?? .topLevel
+            let operationName = parameters.operationName
+            InstrumentationSystem.instrument.extract(requestHead.headers, into: &serviceContext, using: HTTPHeadersExtractor())
+            
+            let span = InstrumentationSystem.tracer.startSpan(operationName, context: serviceContext, ofKind: .server)
+            
+            var attributes: SpanAttributes = [:]
+            
+            attributes["aws.operation"] = operationName
+            attributes["http.method"] = requestHead.method.rawValue
+            attributes["http.target"] = requestHead.uri
+            attributes["http.flavor"] = "\(requestHead.version.major).\(requestHead.version.minor)"
+            attributes["http.user_agent"] = requestHead.headers.first(name: "user-agent")
+            attributes["http.request_content_length"] = requestHead.headers.first(name: "content-length")
+            
+            span.attributes = attributes
+            
+            self.span = span
+        } else {
+            self.span = nil
+        }
     }
     
     public func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?, logger: inout Logger, internalRequestId: String) {
@@ -105,6 +141,10 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             logMetadata["bodyData"] = "\(bodyData.debugString)"
         }
         
+        if let span = self.span {
+            span.attributes["smoke.internalRequestId"] = internalRequestId
+        }
+        
         // log details about the incoming request
         logger.info("Incoming request received.", metadata: logMetadata)
     }
@@ -122,10 +162,16 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
         var logMetadata: Logger.Metadata = ["status": "\(status.reasonPhrase)",
                                             "statusCode": "\(status.code)"]
         
+        let bodyData: String?
         if let body = body {
+            let theBodyData = body.data.debugString
             logMetadata["contentType"] = "\(body.contentType)"
             logMetadata["bodyBytesCount"] = "\(body.data.count)"
-            logMetadata["bodyData"] = "\(body.data.debugString)"
+            logMetadata["bodyData"] = "\(theBodyData)"
+            
+            bodyData = theBodyData
+        } else {
+            bodyData = nil
         }
         
         let level: Logger.Level
@@ -134,6 +180,20 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             level = .error
         } else {
             level = .info
+        }
+        
+        if let span = self.span {
+            span.attributes["http.status_code"] = Int(status.code)
+            
+            if status.code >= 500 && status.code < 600 {
+                if let bodyData = bodyData {
+                    span.recordError(OperationFailure.withResponseBody(bodyData))
+                } else {
+                    span.recordError(OperationFailure.withNoResponseBody)
+                }
+            }
+            
+            span.end()
         }
         
         logger.log(level: level, "Response to incoming request sent.", metadata: logMetadata)
@@ -221,5 +281,11 @@ extension SmokeInvocationTraceContext: InvocationTraceContext {
         }
         
         logger.log(level: level, "Outgoing request completed.", metadata: logMetadata)
+    }
+}
+
+private struct HTTPHeadersExtractor: Extractor {
+    func extract(key name: String, from headers: HTTPHeaders) -> String? {
+        headers.first(name: name)
     }
 }

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -100,6 +100,7 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             self.traceId = nil
         }
         
+#if swift(>=5.7.0)
         if case .ifRequired(let parameters) = options?.createRequestSpan {
             var serviceContext = ServiceContext.current ?? .topLevel
             let operationName = parameters.operationName
@@ -122,6 +123,9 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
         } else {
             self.span = nil
         }
+#else
+        self.span = nil
+#endif
     }
     
     public func handleInwardsRequestStart(requestHead: HTTPRequestHead, bodyData: Data?, logger: inout Logger, internalRequestId: String) {

--- a/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
+++ b/Sources/SmokeOperationsHTTP1/StandardHTTP1OperationRequestHandler.swift
@@ -43,6 +43,19 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
         SmokeInvocationContext<SelectorType.DefaultOperationDelegateType.InvocationReportingType> == SelectorType.DefaultOperationDelegateType.ResponseHandlerType.InvocationContext {
     public typealias ResponseHandlerType = SelectorType.DefaultOperationDelegateType.ResponseHandlerType
     
+    // The providers that are used to delay some actions
+    public struct Actions {
+        // used to instantiate invocationReporting from a decorated logger
+        public let invocationReportingProvider: (Logger) -> InvocationReportingType
+        // used to call `handleInwardsRequestStart` on the trace context after ping requests have been handled
+        public let requestStartTraceAction: (() -> (Logger))?
+        
+        public init(invocationReportingProvider: @escaping (Logger) -> InvocationReportingType,
+                    requestStartTraceAction: (() -> (Logger))?) {
+            self.invocationReportingProvider = invocationReportingProvider
+            self.requestStartTraceAction = requestStartTraceAction
+        }
+    }
     
     typealias InvocationContext = ResponseHandlerType.InvocationContext
     public typealias InvocationReportingType = SelectorType.DefaultOperationDelegateType.InvocationReportingType
@@ -53,10 +66,12 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
     let unknownOperationReporting: SmokeOperationReporting
     let errorDeterminingOperationReporting: SmokeOperationReporting
     let requestExecutor: RequestExecutor
+    let enableTracingWithSwiftConcurrency: Bool
     
     public init(handlerSelector: SelectorType, context: SelectorType.ContextType, serverName: String,
                 reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer>,
-                requestExecutor: RequestExecutor = .originalEventLoop) {
+                requestExecutor: RequestExecutor = .originalEventLoop,
+                enableTracingWithSwiftConcurrency: Bool = false) {
         self.handlerSelector = handlerSelector
         self.context = .static(context)
         
@@ -68,12 +83,14 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
                                                                                 request: .errorDeterminingOperation,
                                                                                 configuration: reportingConfiguration)
         self.requestExecutor = requestExecutor
+        self.enableTracingWithSwiftConcurrency = enableTracingWithSwiftConcurrency
     }
     
     public init(handlerSelector: SelectorType,
                 contextProvider: @escaping (InvocationReportingType) -> SelectorType.ContextType,
                 serverName: String, reportingConfiguration: SmokeReportingConfiguration<SelectorType.OperationIdentifer>,
-                requestExecutor: RequestExecutor = .originalEventLoop) {
+                requestExecutor: RequestExecutor = .originalEventLoop,
+                enableTracingWithSwiftConcurrency: Bool = false) {
         self.handlerSelector = handlerSelector
         self.context = .provider(contextProvider)
         
@@ -85,6 +102,7 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
                                                                                 request: .errorDeterminingOperation,
                                                                                 configuration: reportingConfiguration)
         self.requestExecutor = requestExecutor
+        self.enableTracingWithSwiftConcurrency = enableTracingWithSwiftConcurrency
     }
     
     private func getInvocationContextForAnonymousRequest(requestReporting: SmokeOperationReporting,
@@ -99,26 +117,65 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
                                       requestReporting: requestReporting)
     }
     
+    /**
+     The original handle method, retained for backwards compatibility.
+     The `invocationReportingProvider` is a workaround to construct the InvocationReporting
+     instance from an appropriately decorated `Logger`.
+     */
     public func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                        invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String,
                        invocationReportingProvider: @escaping (Logger) -> InvocationReportingType) {
-        handle(requestHead: requestHead, body: body, responseHandler: responseHandler,
-               invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
-               invocationReportingProvider: invocationReportingProvider,
-               requestStartTraceAction: nil)
+        let actions = Actions(invocationReportingProvider: invocationReportingProvider, requestStartTraceAction: nil)
+        
+        handleForActionsProvider(requestHead: requestHead, body: body, responseHandler: responseHandler,
+                                 invocationStrategy: invocationStrategy, requestLogger: requestLogger,
+                                 internalRequestId: internalRequestId, actionsProvider: { _ in actions })
     }
-
+    
+    /**
+     An updated handle method but now also retained for backwards compatibility.
+     The `invocationReportingProvider` is a workaround to construct the InvocationReporting
+     instance from an appropriately decorated `Logger`.
+     The `requestStartTraceAction` is a workaround to call `handleInwardsRequestStart` on the
+     trace context after ping requests have been handled
+     */
     public func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
                        invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String,
                        invocationReportingProvider: @escaping (Logger) -> InvocationReportingType,
                        requestStartTraceAction: (() -> (Logger))?) {
+        let actions = Actions(invocationReportingProvider: invocationReportingProvider,
+                              requestStartTraceAction: requestStartTraceAction)
+        
+        handleForActionsProvider(requestHead: requestHead, body: body, responseHandler: responseHandler,
+                                 invocationStrategy: invocationStrategy, requestLogger: requestLogger,
+                                 internalRequestId: internalRequestId, actionsProvider: { _ in actions })
+    }
+    
+    /**
+     The currently used handle method where actions can be created based on a provided options instance.
+     */
+    public func handle(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
+                       invocationStrategy: InvocationStrategy, requestLogger: Logger, internalRequestId: String,
+                       actionsProvider: @escaping (OperationTraceContextOptions?) -> Actions) {
+        handleForActionsProvider(requestHead: requestHead, body: body, responseHandler: responseHandler,
+                                 invocationStrategy: invocationStrategy, requestLogger: requestLogger,
+                                 internalRequestId: internalRequestId,actionsProvider: actionsProvider)
+    }
+
+    private func handleForActionsProvider(requestHead: HTTPRequestHead, body: Data?,
+                                          responseHandler: ResponseHandlerType,
+                                          invocationStrategy: InvocationStrategy,
+                                          requestLogger: Logger, internalRequestId: String,
+                                          actionsProvider: @escaping (OperationTraceContextOptions?) -> Actions) {
         // this is the ping url
         if requestHead.uri == PingParameters.uri {
             let body = (contentType: "text/plain", data: PingParameters.payload)
+            let actions = actionsProvider(nil)
             let responseComponents = HTTP1ServerResponseComponents(additionalHeaders: [], body: body)
-            let invocationContext = getInvocationContextForAnonymousRequest(requestReporting: pingOperationReporting,
-                                                                            requestLogger: requestLogger,
-                                                                            invocationReportingProvider: invocationReportingProvider)
+            let invocationContext = getInvocationContextForAnonymousRequest(
+                requestReporting: pingOperationReporting,
+                requestLogger: requestLogger,
+                invocationReportingProvider: actions.invocationReportingProvider)
             responseHandler.completeSilentlyInEventLoop(invocationContext: invocationContext,
                                                         status: .ok, responseComponents: responseComponents)
             
@@ -129,33 +186,26 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
         case .cooperativeTaskGroup:
             Task {
                 handleOnDesiredThreadPool(requestHead: requestHead, body: body, responseHandler: responseHandler,
-                                          invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
-                                          invocationReportingProvider: invocationReportingProvider, requestStartTraceAction: requestStartTraceAction)
+                                          invocationStrategy: invocationStrategy, requestLogger: requestLogger,
+                                          internalRequestId: internalRequestId, actionsProvider: actionsProvider)
             }
         case .dispatchQueue:
             DispatchQueue.global().async {
                 handleOnDesiredThreadPool(requestHead: requestHead, body: body, responseHandler: responseHandler,
-                                          invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
-                                          invocationReportingProvider: invocationReportingProvider, requestStartTraceAction: requestStartTraceAction)
+                                          invocationStrategy: invocationStrategy, requestLogger: requestLogger,
+                                          internalRequestId: internalRequestId, actionsProvider: actionsProvider)
             }
         case .originalEventLoop:
             handleOnDesiredThreadPool(requestHead: requestHead, body: body, responseHandler: responseHandler,
-                                      invocationStrategy: invocationStrategy, requestLogger: requestLogger, internalRequestId: internalRequestId,
-                                      invocationReportingProvider: invocationReportingProvider, requestStartTraceAction: requestStartTraceAction)
+                                      invocationStrategy: invocationStrategy, requestLogger: requestLogger,
+                                      internalRequestId: internalRequestId, actionsProvider: actionsProvider)
         }
     }
     
     private func handleOnDesiredThreadPool(requestHead: HTTPRequestHead, body: Data?, responseHandler: ResponseHandlerType,
-                                           invocationStrategy: InvocationStrategy, requestLogger originalLogger: Logger, internalRequestId: String,
-                                           invocationReportingProvider: @escaping (Logger) -> InvocationReportingType,
-                                           requestStartTraceAction: (() -> (Logger))?) {
-        let requestLogger: Logger
-        if let requestStartTraceAction = requestStartTraceAction {
-            requestLogger = requestStartTraceAction()
-        } else {
-            requestLogger = originalLogger
-        }
-        
+                                           invocationStrategy: InvocationStrategy, requestLogger originalLogger: Logger,
+                                           internalRequestId: String,
+                                           actionsProvider: (OperationTraceContextOptions?) -> Actions) {
         let uriComponents = requestHead.uri.split(separator: "?", maxSplits: 1)
         let path = String(uriComponents[0])
         let query = uriComponents.count > 1 ? String(uriComponents[1]) : ""
@@ -169,15 +219,20 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
         do {
             (handler, shape) = try handlerSelector.getHandlerForOperation(
                 path,
-                httpMethod: requestHead.method, requestLogger: requestLogger)
+                httpMethod: requestHead.method, requestLogger: originalLogger)
         } catch SmokeOperationsError.invalidOperation(reason: let reason) {
             let smokeHTTP1RequestHead = SmokeHTTP1RequestHead(httpRequestHead: requestHead,
                                                               query: query,
                                                               pathShape: .null)
             
-            let invocationContext = getInvocationContextForAnonymousRequest(requestReporting: unknownOperationReporting,
-                                                                            requestLogger: requestLogger,
-                                                                            invocationReportingProvider: invocationReportingProvider)
+            let tracingOptions = getTracingOptions(for: "InvalidOperation")
+            let actions = actionsProvider(tracingOptions)
+            let requestLogger = actions.requestStartTraceAction?() ?? originalLogger
+            
+            let invocationContext = getInvocationContextForAnonymousRequest(
+                requestReporting: unknownOperationReporting,
+                requestLogger: requestLogger,
+                invocationReportingProvider: actions.invocationReportingProvider)
             defaultOperationDelegate.handleResponseForInvalidOperation(
                 requestHead: smokeHTTP1RequestHead,
                 message: reason,
@@ -185,15 +240,20 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
                 invocationContext: invocationContext)
             return
         } catch {
+            let tracingOptions = getTracingOptions(for: "FailedHandlerSelection")
+            let actions = actionsProvider(tracingOptions)
+            let requestLogger = actions.requestStartTraceAction?() ?? originalLogger
+            
             requestLogger.error("Unexpected handler selection error.",
                                 metadata: ["cause": "\(String(describing: error))"])
             let smokeHTTP1RequestHead = SmokeHTTP1RequestHead(httpRequestHead: requestHead,
                                                               query: query,
                                                               pathShape: .null)
             
-            let invocationContext = getInvocationContextForAnonymousRequest(requestReporting: errorDeterminingOperationReporting,
-                                                                            requestLogger: requestLogger,
-                                                                            invocationReportingProvider: invocationReportingProvider)
+            let invocationContext = getInvocationContextForAnonymousRequest(
+                requestReporting: errorDeterminingOperationReporting,
+                requestLogger: requestLogger,
+                invocationReportingProvider: actions.invocationReportingProvider)
             defaultOperationDelegate.handleResponseForInternalServerError(
                 requestHead: smokeHTTP1RequestHead,
                 responseHandler: responseHandler,
@@ -205,10 +265,27 @@ public struct StandardHTTP1OperationRequestHandler<SelectorType>: HTTP1Operation
                                                           query: query,
                                                           pathShape: shape)
         
+        let tracingOptions = getTracingOptions(for: handler.operationIdentifer.description)
+        let actions = actionsProvider(tracingOptions)
+        let requestLogger = actions.requestStartTraceAction?() ?? originalLogger
+        
         // let it be handled
         handler.handle(smokeHTTP1RequestHead, body: body, withContext: context,
                        responseHandler: responseHandler, invocationStrategy: invocationStrategy,
                        requestLogger: requestLogger, internalRequestId: internalRequestId,
-                       invocationReportingProvider: invocationReportingProvider)
+                       invocationReportingProvider: actions.invocationReportingProvider)
+    }
+    
+    private func getTracingOptions(for operationName: String)
+    -> OperationTraceContextOptions {
+        let createRequestSpan: CreateRequestSpan
+        if self.enableTracingWithSwiftConcurrency {
+            let parameters = RequestSpanParameters(operationName: operationName)
+            createRequestSpan = .ifRequired(parameters)
+        } else {
+            createRequestSpan = .never
+        }
+        
+        return .init(createRequestSpan: createRequestSpan)
     }
 }

--- a/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerPerInvocationContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerPerInvocationContextInitializer.swift
@@ -27,6 +27,7 @@ public protocol SmokeAsyncServerPerInvocationContextInitializer: SmokeAsyncPerIn
     var shutdownOnSignals: [SmokeHTTP1Server.ShutdownOnSignal] { get }
     var eventLoopProvider: SmokeHTTP1Server.EventLoopProvider { get }
     var requestExecutor: RequestExecutor { get }
+    var enableTracingWithSwiftConcurrency: Bool { get }
 }
 
 public extension SmokeAsyncServerPerInvocationContextInitializer {
@@ -44,6 +45,10 @@ public extension SmokeAsyncServerPerInvocationContextInitializer {
     
     var requestExecutor: RequestExecutor {
         return .originalEventLoop
+    }
+    
+    var enableTracingWithSwiftConcurrency: Bool {
+        return false
     }
 }
 #endif

--- a/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerStaticContextInitializer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeAsyncServerStaticContextInitializer.swift
@@ -27,6 +27,7 @@ public protocol SmokeAsyncServerStaticContextInitializer: SmokeAsyncStaticContex
     var shutdownOnSignals: [SmokeHTTP1Server.ShutdownOnSignal] { get }
     var eventLoopProvider: SmokeHTTP1Server.EventLoopProvider { get }
     var requestExecutor: RequestExecutor { get }
+    var enableTracingWithSwiftConcurrency: Bool { get }
 }
 
 public extension SmokeAsyncServerStaticContextInitializer {
@@ -44,6 +45,10 @@ public extension SmokeAsyncServerStaticContextInitializer {
     
     var requestExecutor: RequestExecutor {
         return .originalEventLoop
+    }
+    
+    var enableTracingWithSwiftConcurrency: Bool {
+        return false
     }
 }
 #endif

--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
@@ -67,7 +67,9 @@ public extension SmokeHTTP1Server {
         do {
             initalizer = try factory(eventLoopGroup)
         } catch {
-            let logger = Logger.init(label: "application.initialization")
+            // create a logger that will, regardless of what logging backend was bootstrapped, will log immediately
+            // to standard out
+            let logger = Logger.init(label: "application.initialization") { StreamLogHandler.standardOutput(label: $0) }
             
             logger.error("Unable to initialize application from factory.",
                          metadata: ["cause": "\(String(describing: error))"])
@@ -130,7 +132,9 @@ public extension SmokeHTTP1Server {
         do {
             initalizer = try factory(eventLoopGroup)
         } catch {
-            let logger = Logger.init(label: "application.initialization")
+            // create a logger that will, regardless of what logging backend was bootstrapped, will log immediately
+            // to standard out
+            let logger = Logger.init(label: "application.initialization") { StreamLogHandler.standardOutput(label: $0) }
             
             logger.error("Unable to initialize application from factory.",
                          metadata: ["cause": "\(String(describing: error))"])
@@ -193,7 +197,9 @@ public extension SmokeHTTP1Server {
         do {
             initalizer = try factory(eventLoopGroup)
         } catch {
-            let logger = Logger.init(label: "application.initialization")
+            // create a logger that will, regardless of what logging backend was bootstrapped, will log immediately
+            // to standard out
+            let logger = Logger.init(label: "application.initialization") { StreamLogHandler.standardOutput(label: $0) }
             
             logger.error("Unable to initialize application from factory.",
                          metadata: ["cause": "\(String(describing: error))"])
@@ -259,7 +265,9 @@ public extension SmokeHTTP1Server {
         do {
             initalizer = try factory(eventLoopGroup)
         } catch {
-            let logger = Logger.init(label: "application.initialization")
+            // create a logger that will, regardless of what logging backend was bootstrapped, will log immediately
+            // to standard out
+            let logger = Logger.init(label: "application.initialization") { StreamLogHandler.standardOutput(label: $0) }
             
             logger.error("Unable to initialize application from factory.",
                          metadata: ["cause": "\(String(describing: error))"])
@@ -326,7 +334,9 @@ public extension SmokeHTTP1Server {
         do {
             initalizer = try await factory(eventLoopGroup)
         } catch {
-            let logger = Logger.init(label: "application.initialization")
+            // create a logger that will, regardless of what logging backend was bootstrapped, will log immediately
+            // to standard out
+            let logger = Logger.init(label: "application.initialization") { StreamLogHandler.standardOutput(label: $0) }
             
             logger.error("Unable to initialize application from factory.",
                          metadata: ["cause": "\(String(describing: error))"])
@@ -389,7 +399,9 @@ public extension SmokeHTTP1Server {
         do {
             initalizer = try await factory(eventLoopGroup)
         } catch {
-            let logger = Logger.init(label: "application.initialization")
+            // create a logger that will, regardless of what logging backend was bootstrapped, will log immediately
+            // to standard out
+            let logger = Logger.init(label: "application.initialization") { StreamLogHandler.standardOutput(label: $0) }
             
             logger.error("Unable to initialize application from factory.",
                          metadata: ["cause": "\(String(describing: error))"])

--- a/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeHTTP1Server+runAsOperationServer.swift
@@ -355,7 +355,8 @@ public extension SmokeHTTP1Server {
             context: initalizer.getInvocationContext(),
             serverName: initalizer.serverName,
             reportingConfiguration: initalizer.reportingConfiguration,
-            requestExecutor: initalizer.requestExecutor)
+            requestExecutor: initalizer.requestExecutor,
+            enableTracingWithSwiftConcurrency: initalizer.enableTracingWithSwiftConcurrency)
         let server = StandardSmokeHTTP1Server(handler: handler,
                                               port: initalizer.port,
                                               invocationStrategy: initalizer.invocationStrategy,
@@ -417,7 +418,8 @@ public extension SmokeHTTP1Server {
             contextProvider: initalizer.getInvocationContext,
             serverName: initalizer.serverName,
             reportingConfiguration: initalizer.reportingConfiguration,
-            requestExecutor: initalizer.requestExecutor)
+            requestExecutor: initalizer.requestExecutor,
+            enableTracingWithSwiftConcurrency: initalizer.enableTracingWithSwiftConcurrency)
         let server = StandardSmokeHTTP1Server(handler: handler,
                                               port: initalizer.port,
                                               invocationStrategy: initalizer.invocationStrategy,

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting.swift
@@ -20,6 +20,7 @@ import SmokeOperations
 import Logging
 import NIO
 import SmokeHTTPClient
+import Tracing
 
 public protocol InvocationReportingWithTraceContext: InvocationReporting {
     associatedtype TraceContextType: OperationTraceContext
@@ -37,6 +38,10 @@ public struct SmokeServerInvocationReporting<TraceContextType: OperationTraceCon
     public let outwardsRequestAggregator: OutwardsRequestAggregator?
     public let internalRequestId: String
     public let traceContext: TraceContextType
+    
+    public var span: Span? {
+        return self.traceContext.span
+    }
     
     public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType,
                 eventLoop: EventLoop? = nil, outwardsRequestAggregator: OutwardsRequestAggregator? = nil) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Integrated as described [here](https://github.com/apple/swift-distributed-tracing/blob/main/Sources/Tracing/Docs.docc/Guides/InstrumentYourLibrary.md). Verified the traceId is extracted from the incoming request and then is available to be propagated to outgoing downstream requests as expected.

The various aspects of tracing happen at different points-
1. The application initialiser provides an option - `enableTracingWithSwiftConcurrency` - to enable tracing.
1. StandardHTTP1OperationRequestHandler: Determines if tracing is enabled, and passes an options instance to the `OperationTraceContext` instance being constructed indicating if a span can be created.
2. The `OperationHandler` input handlers call the operation in a scope where the `ServiceContext` is available via a TaskLocal. The `ServiceContext` is retrieved from the span provided by the current `InvocationReporting` instance. `SmokeServerInvocationReporting` retrieves this from the `OperationTraceContext`.
3. The implementation of the `OperationTraceContext` (by default `SmokeInvocationTraceContext`) ultimately determines if a span is created, creating it from the options passed to it and closing it in its `handleInwardsRequestComplete` function.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
