### PR TITLE
Distributed tracing improvements

### DIFF
--- a/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
@@ -53,31 +53,27 @@ public extension OperationHandler {
                                  responseHandler: ResponseHandlerType,
                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
             Task {
-                let handlerResult: NoOutputOperationHandlerResult<ErrorType>
-                do {
-                    if let span = invocationContext.invocationReporting.span {
-                        try await ServiceContext.withValue(span.context) {
-                            try await operation(input, context, invocationContext.invocationReporting)
-                        }
-                    } else {
+                await Self.withSpanContext(invocationContext: invocationContext) {
+                    let handlerResult: NoOutputOperationHandlerResult<ErrorType>
+                    do {
                         try await operation(input, context, invocationContext.invocationReporting)
+                        
+                        handlerResult = .success
+                    } catch let smokeReturnableError as SmokeReturnableError {
+                        handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+                    } catch SmokeOperationsError.validationError(reason: let reason) {
+                        handlerResult = .validationError(reason)
+                    } catch {
+                        handlerResult = .internalServerError(error)
                     }
                     
-                    handlerResult = .success
-                } catch let smokeReturnableError as SmokeReturnableError {
-                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
-                } catch SmokeOperationsError.validationError(reason: let reason) {
-                    handlerResult = .validationError(reason)
-                } catch {
-                    handlerResult = .internalServerError(error)
+                    OperationHandler.handleNoOutputOperationHandlerResult(
+                        handlerResult: handlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        invocationContext: invocationContext)
                 }
-                
-                OperationHandler.handleNoOutputOperationHandlerResult(
-                    handlerResult: handlerResult,
-                    operationDelegate: operationDelegate,
-                    requestHead: requestHead,
-                    responseHandler: responseHandler,
-                    invocationContext: invocationContext)
             }
         }
         

--- a/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
@@ -56,33 +56,28 @@ public extension OperationHandler {
                                  responseHandler: OperationDelegateType.ResponseHandlerType,
                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
             Task {
-                let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
-                do {
-                    let output: OutputType
-                    if let span = invocationContext.invocationReporting.span {
-                        output = try await ServiceContext.withValue(span.context) {
-                            return try await operation(input, context, invocationContext.invocationReporting)
-                        }
-                    } else {
-                        output = try await operation(input, context, invocationContext.invocationReporting)
+                await Self.withSpanContext(invocationContext: invocationContext) {
+                    let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
+                    do {
+                        let output = try await operation(input, context, invocationContext.invocationReporting)
+                        
+                        handlerResult = .success(output)
+                    } catch let smokeReturnableError as SmokeReturnableError {
+                        handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+                    } catch SmokeOperationsError.validationError(reason: let reason) {
+                        handlerResult = .validationError(reason)
+                    } catch {
+                        handlerResult = .internalServerError(error)
                     }
-                                        
-                    handlerResult = .success(output)
-                } catch let smokeReturnableError as SmokeReturnableError {
-                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
-                } catch SmokeOperationsError.validationError(reason: let reason) {
-                    handlerResult = .validationError(reason)
-                } catch {
-                    handlerResult = .internalServerError(error)
+                    
+                    OperationHandler.handleWithOutputOperationHandlerResult(
+                        handlerResult: handlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        outputHandler: outputHandler,
+                        invocationContext: invocationContext)
                 }
-                
-                OperationHandler.handleWithOutputOperationHandlerResult(
-                    handlerResult: handlerResult,
-                    operationDelegate: operationDelegate,
-                    requestHead: requestHead,
-                    responseHandler: responseHandler,
-                    outputHandler: outputHandler,
-                    invocationContext: invocationContext)
             }
         }
         

--- a/Sources/SmokeOperations/OperationHandlerExtensions.swift
+++ b/Sources/SmokeOperations/OperationHandlerExtensions.swift
@@ -16,6 +16,7 @@
 //
 import Foundation
 import Logging
+import Tracing
 
 /**
  Possible results of an operation that has no output.

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -123,7 +123,7 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             
             self.parentSpan = parentSpan
             
-            self.span = InstrumentationSystem.tracer.startSpan(operationName, context: serviceContext)
+            self.span = InstrumentationSystem.tracer.startSpan(operationName, context: parentSpan.context)
         } else {
             self.parentSpan = nil
             self.span = nil

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -54,13 +54,16 @@ public struct SmokeInvocationTraceContext {
     private let externalRequestId: String?
     private let traceId: String?
     
+    private let parentSpan: Span?
     public let span: Span?
     
     public init(externalRequestId: String? = nil,
                 traceId: String? = nil,
+                parentSpan: Span? = nil,
                 span: Span? = nil) {
         self.externalRequestId = externalRequestId
         self.traceId = traceId
+        self.parentSpan = parentSpan
         self.span = span
     }
 }
@@ -106,24 +109,27 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             let operationName = parameters.operationName
             InstrumentationSystem.instrument.extract(requestHead.headers, into: &serviceContext, using: HTTPHeadersExtractor())
             
-            let span = InstrumentationSystem.tracer.startSpan(operationName, context: serviceContext, ofKind: .server)
+            let parentSpan = InstrumentationSystem.tracer.startSpan("ServerRequest", context: serviceContext, ofKind: .server)
             
             var attributes: SpanAttributes = [:]
             
-            attributes["aws.operation"] = operationName
             attributes["http.method"] = requestHead.method.rawValue
             attributes["http.target"] = requestHead.uri
             attributes["http.flavor"] = "\(requestHead.version.major).\(requestHead.version.minor)"
             attributes["http.user_agent"] = requestHead.headers.first(name: "user-agent")
             attributes["http.request_content_length"] = requestHead.headers.first(name: "content-length")
             
-            span.attributes = attributes
+            parentSpan.attributes = attributes
             
-            self.span = span
+            self.parentSpan = parentSpan
+            
+            self.span = InstrumentationSystem.tracer.startSpan(operationName, context: serviceContext)
         } else {
+            self.parentSpan = nil
             self.span = nil
         }
 #else
+        self.parentSpan = nil
         self.span = nil
 #endif
     }
@@ -198,6 +204,10 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             }
             
             span.end()
+        }
+        
+        if let parentSpan = self.parentSpan {
+            parentSpan.end()
         }
         
         logger.log(level: level, "Response to incoming request sent.", metadata: logMetadata)

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -151,12 +151,18 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             logMetadata["bodyData"] = "\(bodyData.debugString)"
         }
         
-        if let span = self.span {
-            span.attributes["smoke.internalRequestId"] = internalRequestId
+        func logIncomingRequest() {
+            // log details about the incoming request
+            logger.info("Incoming request received.", metadata: logMetadata)
         }
         
-        // log details about the incoming request
-        logger.info("Incoming request received.", metadata: logMetadata)
+        if let span = self.span {
+            span.attributes["smoke.internalRequestId"] = internalRequestId
+            
+            ServiceContext.withValue(span.context, operation: logIncomingRequest)
+        } else {
+            logIncomingRequest()
+        }
     }
     
     public func handleInwardsRequestComplete(httpHeaders: inout HTTPHeaders, status: HTTPResponseStatus,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Make a number of improvements to how distributed tracing is used- 

1. Create an internal tracing span for the operation selected. This makes it clearer what operation has been used. In a future fully-structured-concurrency architecture, the two spans can be started at the appropriate times during request handling but for now they are started and completed together.
2. Ensure that logs emitted by the framework (request start, request end, report request metrics) will contain metadata for the span (span-id, trace-id), allowing for these logs to be associated with the span/trace. This was tested under the following scenarios- failure due to missing input, failure due to input decoding failure, failure due to operation returning a validation failure, failure due to operation returning a modelled service error and a successful operation response.
3. Addressed an issue where the `ResponseExecutor` selection of `GenericJSONPayloadHTTP1OperationDelegate` was not honoured in some situations (when the operation returned an error).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
