### PR TITLE
Distributed tracing improvements.

### DIFF
--- a/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputNoOutput.swift
@@ -53,31 +53,27 @@ public extension OperationHandler {
                                  responseHandler: ResponseHandlerType,
                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
             Task {
-                let handlerResult: NoOutputOperationHandlerResult<ErrorType>
-                do {
-                    if let span = invocationContext.invocationReporting.span {
-                        try await ServiceContext.withValue(span.context) {
-                            try await operation(input, context, invocationContext.invocationReporting)
-                        }
-                    } else {
+                await Self.withSpanContext(invocationContext: invocationContext) {
+                    let handlerResult: NoOutputOperationHandlerResult<ErrorType>
+                    do {
                         try await operation(input, context, invocationContext.invocationReporting)
+                        
+                        handlerResult = .success
+                    } catch let smokeReturnableError as SmokeReturnableError {
+                        handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+                    } catch SmokeOperationsError.validationError(reason: let reason) {
+                        handlerResult = .validationError(reason)
+                    } catch {
+                        handlerResult = .internalServerError(error)
                     }
                     
-                    handlerResult = .success
-                } catch let smokeReturnableError as SmokeReturnableError {
-                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
-                } catch SmokeOperationsError.validationError(reason: let reason) {
-                    handlerResult = .validationError(reason)
-                } catch {
-                    handlerResult = .internalServerError(error)
+                    OperationHandler.handleNoOutputOperationHandlerResult(
+                        handlerResult: handlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        invocationContext: invocationContext)
                 }
-                
-                OperationHandler.handleNoOutputOperationHandlerResult(
-                    handlerResult: handlerResult,
-                    operationDelegate: operationDelegate,
-                    requestHead: requestHead,
-                    responseHandler: responseHandler,
-                    invocationContext: invocationContext)
             }
         }
         

--- a/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
+++ b/Sources/SmokeOperations/OperationHandler+withContextInputWithOutput.swift
@@ -56,33 +56,28 @@ public extension OperationHandler {
                                  responseHandler: OperationDelegateType.ResponseHandlerType,
                                  invocationContext: SmokeInvocationContext<InvocationReportingType>) {
             Task {
-                let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
-                do {
-                    let output: OutputType
-                    if let span = invocationContext.invocationReporting.span {
-                        output = try await ServiceContext.withValue(span.context) {
-                            return try await operation(input, context, invocationContext.invocationReporting)
-                        }
-                    } else {
-                        output = try await operation(input, context, invocationContext.invocationReporting)
+                await Self.withSpanContext(invocationContext: invocationContext) {
+                    let handlerResult: WithOutputOperationHandlerResult<OutputType, ErrorType>
+                    do {
+                        let output = try await operation(input, context, invocationContext.invocationReporting)
+                        
+                        handlerResult = .success(output)
+                    } catch let smokeReturnableError as SmokeReturnableError {
+                        handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
+                    } catch SmokeOperationsError.validationError(reason: let reason) {
+                        handlerResult = .validationError(reason)
+                    } catch {
+                        handlerResult = .internalServerError(error)
                     }
-                                        
-                    handlerResult = .success(output)
-                } catch let smokeReturnableError as SmokeReturnableError {
-                    handlerResult = .smokeReturnableError(smokeReturnableError, allowedErrors)
-                } catch SmokeOperationsError.validationError(reason: let reason) {
-                    handlerResult = .validationError(reason)
-                } catch {
-                    handlerResult = .internalServerError(error)
+                    
+                    OperationHandler.handleWithOutputOperationHandlerResult(
+                        handlerResult: handlerResult,
+                        operationDelegate: operationDelegate,
+                        requestHead: requestHead,
+                        responseHandler: responseHandler,
+                        outputHandler: outputHandler,
+                        invocationContext: invocationContext)
                 }
-                
-                OperationHandler.handleWithOutputOperationHandlerResult(
-                    handlerResult: handlerResult,
-                    operationDelegate: operationDelegate,
-                    requestHead: requestHead,
-                    responseHandler: responseHandler,
-                    outputHandler: outputHandler,
-                    invocationContext: invocationContext)
             }
         }
         


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Make a number of improvements to how distributed tracing is used- 

1. Create an internal tracing span for the operation selected. This makes it clearer what operation has been used. In a future fully-structured-concurrency architecture, the two spans can be started at the appropriate times during request handling but for now they are started and completed together.
2. Ensure that logs emitted by the framework (request start, request end, report request metrics) will contain metadata for the span (span-id, trace-id), allowing for these logs to be associated with the span/trace. This was tested under the following scenarios- failure due to missing input, failure due to input decoding failure, failure due to operation returning a validation failure, failure due to operation returning a modelled service error and a successful operation response.
3. Addressed an issue where the `ResponseExecutor` selection of `GenericJSONPayloadHTTP1OperationDelegate` was not honoured in some situations (when the operation returned an error).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
