### PR TITLE
Report thrown error to span

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "e866a626e105042a6a72a870c88b4c531ba05f83",
-          "version": "2.24.0"
+          "revision": "320bd978cceb8e88c125dcbb774943a92f6286e9",
+          "version": "2.25.0"
         }
       },
       {

--- a/Sources/SmokeOperations/InvocationReporting.swift
+++ b/Sources/SmokeOperations/InvocationReporting.swift
@@ -26,11 +26,18 @@ public protocol InvocationReporting {
     var logger: Logger { get }
     var internalRequestId: String { get }
     var span: Span? { get }
+    
+    func recordErrorForInvocation(_ error: Swift.Error)
 }
 
 public extension InvocationReporting {
     // Add span property while remaining backwards compatible
     var span: Span? {
         return nil
+    }
+    
+    // Retain backwards-compatibility
+    func recordErrorForInvocation(_ error: Swift.Error) {
+        // be default do nothing
     }
 }

--- a/Sources/SmokeOperations/OperationHandler.swift
+++ b/Sources/SmokeOperations/OperationHandler.swift
@@ -76,8 +76,8 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
                         logger.info("DecodingError: \(description)")
                     }
                     
-                    invocationContext.invocationReporting.span?.recordError(SmokeOperationsError.serializationError(description: description,
-                                                                                                                    reportableType: reportableType))
+                    invocationContext.invocationReporting.recordErrorForInvocation(SmokeOperationsError.serializationError(description: description,
+                                                                                                                           reportableType: reportableType))
                     operationDelegate.handleResponseForDecodingError(
                         requestHead: requestHead,
                         message: description,
@@ -90,7 +90,7 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
                     // attempt to validate the input
                     try input.validate()
                 } catch SmokeOperationsError.validationError(let reason) {
-                    invocationContext.invocationReporting.span?.recordError(SmokeOperationsError.validationError(reason: reason))
+                    invocationContext.invocationReporting.recordErrorForInvocation(SmokeOperationsError.validationError(reason: reason))
                     
                     withSpanContext(invocationContext: invocationContext) {
                         logger.info("ValidationError: \(reason)")
@@ -103,7 +103,7 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
                     }
                     return
                 } catch {
-                    invocationContext.invocationReporting.span?.recordError(error)
+                    invocationContext.invocationReporting.recordErrorForInvocation(error)
                     
                     withSpanContext(invocationContext: invocationContext) {
                         logger.info("ValidationError: \(error)")

--- a/Sources/SmokeOperations/OperationHandler.swift
+++ b/Sources/SmokeOperations/OperationHandler.swift
@@ -76,6 +76,8 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
                         logger.info("DecodingError: \(description)")
                     }
                     
+                    invocationContext.invocationReporting.span?.recordError(SmokeOperationsError.serializationError(description: description,
+                                                                                                                    reportableType: reportableType))
                     operationDelegate.handleResponseForDecodingError(
                         requestHead: requestHead,
                         message: description,
@@ -88,6 +90,8 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
                     // attempt to validate the input
                     try input.validate()
                 } catch SmokeOperationsError.validationError(let reason) {
+                    invocationContext.invocationReporting.span?.recordError(SmokeOperationsError.validationError(reason: reason))
+                    
                     withSpanContext(invocationContext: invocationContext) {
                         logger.info("ValidationError: \(reason)")
                         
@@ -99,6 +103,8 @@ public struct OperationHandler<ContextType, RequestHeadType, InvocationReporting
                     }
                     return
                 } catch {
+                    invocationContext.invocationReporting.span?.recordError(error)
+                    
                     withSpanContext(invocationContext: invocationContext) {
                         logger.info("ValidationError: \(error)")
                         

--- a/Sources/SmokeOperations/OperationHandlerExtensions.swift
+++ b/Sources/SmokeOperations/OperationHandlerExtensions.swift
@@ -109,13 +109,13 @@ public extension OperationHandler {
             case .internalServerError(let error):
                 logger.error("Unexpected failure.",
                              metadata: ["cause": "\(String(describing: error))"])
-                invocationContext.invocationReporting.span?.recordError(error)
+                invocationContext.invocationReporting.recordErrorForInvocation(error)
                 operationDelegate.handleResponseForInternalServerError(
                     requestHead: requestHead,
                     responseHandler: responseHandler,
                     invocationContext: invocationContext)
             case .smokeReturnableError(let error, let allowedErrors):
-                invocationContext.invocationReporting.span?.recordError(error)
+                invocationContext.invocationReporting.recordErrorForInvocation(error)
                 if let operationFailure =
                     OperationHandler.fromSmokeReturnableError(error: error,
                                                               allowedErrors: allowedErrors) {
@@ -139,7 +139,7 @@ public extension OperationHandler {
                     invocationContext: invocationContext)
             case .validationError(let reason):
                 logger.warning("ValidationError: \(reason)")
-                invocationContext.invocationReporting.span?.recordError(SmokeOperationsError.validationError(reason: reason))
+                invocationContext.invocationReporting.recordErrorForInvocation(SmokeOperationsError.validationError(reason: reason))
                 operationDelegate.handleResponseForValidationError(
                     requestHead: requestHead,
                     message: reason,
@@ -176,13 +176,13 @@ public extension OperationHandler {
             case .internalServerError(let error):
                 logger.error("Unexpected failure.",
                              metadata: ["cause": "\(String(describing: error))"])
-                invocationContext.invocationReporting.span?.recordError(error)
+                invocationContext.invocationReporting.recordErrorForInvocation(error)
                 operationDelegate.handleResponseForInternalServerError(
                     requestHead: requestHead,
                     responseHandler: responseHandler,
                     invocationContext: invocationContext)
             case .smokeReturnableError(let error, let allowedErrors):
-                invocationContext.invocationReporting.span?.recordError(error)
+                invocationContext.invocationReporting.recordErrorForInvocation(error)
                 if let operationFailure =
                     OperationHandler.fromSmokeReturnableError(error: error,
                                                               allowedErrors: allowedErrors) {
@@ -205,7 +205,7 @@ public extension OperationHandler {
                     
                     outputHandler(requestHead, output, responseHandler, invocationContext)
                 } catch {
-                    invocationContext.invocationReporting.span?.recordError(error)
+                    invocationContext.invocationReporting.recordErrorForInvocation(error)
                     logger.error("Serialization error: unable to get response.",
                                  metadata: ["cause": "\(String(describing: error))"])
                     
@@ -215,7 +215,7 @@ public extension OperationHandler {
                         invocationContext: invocationContext)
                 }
             case .validationError(let reason):
-                invocationContext.invocationReporting.span?.recordError(SmokeOperationsError.validationError(reason: reason))
+                invocationContext.invocationReporting.recordErrorForInvocation(SmokeOperationsError.validationError(reason: reason))
                 logger.warning("ValidationError: \(reason)")
                 operationDelegate.handleResponseForValidationError(
                     requestHead: requestHead,

--- a/Sources/SmokeOperations/OperationHandlerExtensions.swift
+++ b/Sources/SmokeOperations/OperationHandlerExtensions.swift
@@ -109,11 +109,13 @@ public extension OperationHandler {
             case .internalServerError(let error):
                 logger.error("Unexpected failure.",
                              metadata: ["cause": "\(String(describing: error))"])
+                invocationContext.invocationReporting.span?.recordError(error)
                 operationDelegate.handleResponseForInternalServerError(
                     requestHead: requestHead,
                     responseHandler: responseHandler,
                     invocationContext: invocationContext)
             case .smokeReturnableError(let error, let allowedErrors):
+                invocationContext.invocationReporting.span?.recordError(error)
                 if let operationFailure =
                     OperationHandler.fromSmokeReturnableError(error: error,
                                                               allowedErrors: allowedErrors) {
@@ -137,6 +139,7 @@ public extension OperationHandler {
                     invocationContext: invocationContext)
             case .validationError(let reason):
                 logger.warning("ValidationError: \(reason)")
+                invocationContext.invocationReporting.span?.recordError(SmokeOperationsError.validationError(reason: reason))
                 operationDelegate.handleResponseForValidationError(
                     requestHead: requestHead,
                     message: reason,
@@ -173,11 +176,13 @@ public extension OperationHandler {
             case .internalServerError(let error):
                 logger.error("Unexpected failure.",
                              metadata: ["cause": "\(String(describing: error))"])
+                invocationContext.invocationReporting.span?.recordError(error)
                 operationDelegate.handleResponseForInternalServerError(
                     requestHead: requestHead,
                     responseHandler: responseHandler,
                     invocationContext: invocationContext)
             case .smokeReturnableError(let error, let allowedErrors):
+                invocationContext.invocationReporting.span?.recordError(error)
                 if let operationFailure =
                     OperationHandler.fromSmokeReturnableError(error: error,
                                                               allowedErrors: allowedErrors) {
@@ -200,6 +205,7 @@ public extension OperationHandler {
                     
                     outputHandler(requestHead, output, responseHandler, invocationContext)
                 } catch {
+                    invocationContext.invocationReporting.span?.recordError(error)
                     logger.error("Serialization error: unable to get response.",
                                  metadata: ["cause": "\(String(describing: error))"])
                     
@@ -209,6 +215,7 @@ public extension OperationHandler {
                         invocationContext: invocationContext)
                 }
             case .validationError(let reason):
+                invocationContext.invocationReporting.span?.recordError(SmokeOperationsError.validationError(reason: reason))
                 logger.warning("ValidationError: \(reason)")
                 operationDelegate.handleResponseForValidationError(
                     requestHead: requestHead,

--- a/Sources/SmokeOperations/OperationTraceContext.swift
+++ b/Sources/SmokeOperations/OperationTraceContext.swift
@@ -62,6 +62,8 @@ public protocol OperationTraceContext {
     
     func handleInwardsRequestComplete(httpHeaders: inout ResponseHeadersType, status: ResponseStatusType, body: (contentType: String, data: Data)?,
                                       logger: Logger, internalRequestId: String)
+    
+    func recordErrorForInvocation(_ error: Swift.Error)
 }
 
 public extension OperationTraceContext {
@@ -73,5 +75,10 @@ public extension OperationTraceContext {
     // Add span property while remaining backwards compatible
     var span: Span? {
         return nil
+    }
+    
+    // Retain backwards-compatibility
+    func recordErrorForInvocation(_ error: Swift.Error) {
+        // do nothing by default
     }
 }

--- a/Sources/SmokeOperations/SmokeOperationError.swift
+++ b/Sources/SmokeOperations/SmokeOperationError.swift
@@ -25,6 +25,8 @@ public enum SmokeOperationsError: Error {
     case validationError(reason: String)
     /// There was no registered operation for the incoming request.
     case invalidOperation(reason: String)
+    /// The operation failed due to a serialization error.
+    case serializationError(description: String, reportableType: String?)
 }
 
 /**

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -109,7 +109,7 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             var attributes: SpanAttributes = [:]
             
             attributes["http.method"] = requestHead.method.rawValue
-            attributes["http.target"] = requestHead.uri
+            attributes["http.url"] = requestHead.uri
             attributes["http.flavor"] = "\(requestHead.version.major).\(requestHead.version.minor)"
             attributes["http.user_agent"] = requestHead.headers.first(name: "user-agent")
             attributes["http.request_content_length"] = requestHead.headers.first(name: "content-length")

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -109,7 +109,7 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             var attributes: SpanAttributes = [:]
             
             attributes["http.method"] = requestHead.method.rawValue
-            attributes["http.url"] = requestHead.uri
+            attributes["http.url"] = "http://127.0.0.1\(requestHead.uri)" 
             attributes["http.flavor"] = "\(requestHead.version.major).\(requestHead.version.minor)"
             attributes["http.user_agent"] = requestHead.headers.first(name: "user-agent")
             attributes["http.request_content_length"] = requestHead.headers.first(name: "content-length")

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -199,6 +199,12 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
         
         logger.log(level: level, "Response to incoming request sent.", metadata: logMetadata)
     }
+    
+    public func recordErrorForInvocation(_ error: Swift.Error) {
+        span?.recordError(error)
+        span?.setStatus(.init(code: .error))
+        parentSpan?.setStatus(.init(code: .error))
+    }
 }
     
 extension SmokeInvocationTraceContext: InvocationTraceContext {

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -188,12 +188,12 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
         }
         
         if let span = self.span {
-            span.attributes["http.status_code"] = Int(status.code)
-            
             span.end()
         }
         
         if let parentSpan = self.parentSpan {
+            parentSpan.attributes["http.status_code"] = Int(status.code)
+            
             parentSpan.end()
         }
         

--- a/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
+++ b/Sources/SmokeOperationsHTTP1/SmokeInvocationTraceContext.swift
@@ -179,19 +179,29 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
             logMetadata["bodyData"] = "\(body.data.debugString)"
         }
         
+        let isError = (status.code >= 500 && status.code < 600)
         let level: Logger.Level
         // log at error if this is a server error
-        if status.code >= 500 && status.code < 600 {
+        if isError {
             level = .error
         } else {
             level = .info
         }
         
         if let span = self.span {
+            // log at error if this is a server error
+            if isError {
+                span.setStatus(.init(code: .error))
+            }
             span.end()
         }
         
         if let parentSpan = self.parentSpan {
+            // log at error if this is a server error
+            if isError {
+                parentSpan.setStatus(.init(code: .error))
+            }
+            
             parentSpan.attributes["http.status_code"] = Int(status.code)
             
             parentSpan.end()
@@ -202,8 +212,6 @@ extension SmokeInvocationTraceContext: OperationTraceContext {
     
     public func recordErrorForInvocation(_ error: Swift.Error) {
         span?.recordError(error)
-        span?.setStatus(.init(code: .error))
-        parentSpan?.setStatus(.init(code: .error))
     }
 }
     

--- a/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting.swift
+++ b/Sources/SmokeOperationsHTTP1Server/SmokeServerInvocationReporting.swift
@@ -43,6 +43,10 @@ public struct SmokeServerInvocationReporting<TraceContextType: OperationTraceCon
         return self.traceContext.span
     }
     
+    public func recordErrorForInvocation(_ error: Swift.Error) {
+        self.traceContext.recordErrorForInvocation(error)
+    }
+    
     public init(logger: Logger, internalRequestId: String, traceContext: TraceContextType,
                 eventLoop: EventLoop? = nil, outwardsRequestAggregator: OutwardsRequestAggregator? = nil) {
         self.logger = logger


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Records the root cause of an operation's failure to the distributed trace span, including if it is an internal server failure (5xx) and the error is not specified in the response body itself. This will allow the percise cause of failures to be identified directly from the trace rather than having to consult the corresponding logs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
